### PR TITLE
Wire TLE loading into simulation as optional data source via query param

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,9 +261,74 @@ Target configuration:
 - **HDR Rendering**: Uses `rgba16float` format for intermediate buffers
 - **Texture Views**: Cached to avoid `createView()` calls every frame
 
+## TLE Mode (Real Satellite Data)
+
+The simulation supports loading real Two-Line Element (TLE) data as an alternative
+to the default procedural Walker constellation.
+
+### Activation
+
+Add a `?tle=` query parameter to the URL:
+
+```
+# CelesTrak shorthand names:
+https://your-host/?tle=starlink     # ~6,000 Starlink satellites
+https://your-host/?tle=oneweb       # OneWeb constellation
+https://your-host/?tle=gps          # GPS operational satellites
+https://your-host/?tle=active       # All active satellites (~8,000+)
+
+# Direct URL to any 3-line TLE text file:
+https://your-host/?tle=https://example.com/my-satellites.tle
+```
+
+Without `?tle=`, the default procedural Walker constellation is used.
+
+### Supported CelesTrak Shorthands
+
+`starlink`, `oneweb`, `iridium`, `iridium-next`, `gps`, `galileo`, `stations`, `active`
+
+### Data Flow: TLE Input → GPU Orbital Elements
+
+```
+URL ?tle=starlink
+  → TLELoader.fromCelesTrak('starlink')        [src/data/TLELoader.ts]
+    → fetch() 3-line TLE text from CelesTrak
+    → TLELoader.parse() → TLEData[]
+  → SatelliteGPUBuffer.loadFromTLEData(tles)   [src/core/SatelliteGPUBuffer.ts]
+    → For each TLE: parse line2 fixed-width columns
+      → Extract: inclination, RAAN, mean anomaly (deg → rad)
+      → Derive altitude from mean motion: a = (μ/n²)^(1/3)
+      → Classify into shell 0/1/2 by altitude bracket
+      → Pack into vec4f: [raan, inc, M, (shell<<8)|colorIdx]
+    → Fill remaining slots (up to 1,048,576) with procedural Walker data
+  → uploadOrbitalElements() → GPU read-only storage buffer
+  → Compute shader propagates all 1M positions per frame (same as procedural)
+```
+
+### Padding Behavior
+
+Real TLE counts (~6K) are much smaller than the 1,048,576 buffer. Remaining
+slots are filled deterministically with Walker satellites. The HUD displays
+the data source, e.g. "Source: TLE (6,142 real)".
+
+### Fallback
+
+If TLE fetch/parse fails (network error, CORS, invalid format), the app logs
+a warning and falls back to procedural generation. Startup is never blocked.
+
+### Caveats
+
+- **Scale**: Real constellations have ~6K sats vs 1M procedural. Padded sats
+  use the standard Walker pattern.
+- **Accuracy**: TLEs are propagated with the same simplified circular Keplerian
+  model. Full SGP4 would require compute shader changes.
+- **Epoch**: Simulation uses wall-clock elapsed time, not UTC. Positions drift
+  from reality over time.
+- **CORS**: CelesTrak allows cross-origin. Custom URLs need CORS headers.
+
 ## Known Limitations and TODOs
 
-1. **TLE Loading**: The TLE parser exists but is not wired into the main simulation
+1. ~~**TLE Loading**: The TLE parser exists but is not wired into the main simulation~~ *(Done: use `?tle=` query param)*
 2. **SGP4 Propagation**: Currently using simplified Keplerian mechanics; full SGP4 implementation is stubbed
 3. **J2 Perturbations**: Not yet implemented in the compute shader
 4. **GPU Timing**: Only works if the browser supports `timestamp-query` feature

--- a/src/core/SatelliteGPUBuffer.ts
+++ b/src/core/SatelliteGPUBuffer.ts
@@ -7,6 +7,7 @@
 
 import type WebGPUContext from './WebGPUContext.js';
 import { CONSTANTS, BUFFER_SIZES, INCLINATION_SHELLS } from '@/types/constants.js';
+import type { TLEData } from '@/types/index.js';
 
 /** Buffer pair for double-buffering */
 export interface BufferPair {
@@ -215,6 +216,114 @@ export class SatelliteGPUBuffer {
     console.log(`[SatelliteGPUBuffer] Generated elements in ${elapsed.toFixed(2)}ms`);
 
     return this.orbitalElementData;
+  }
+
+  /**
+   * Load orbital elements from parsed TLE data.
+   *
+   * Data flow: TLE text → TLELoader.parse() → TLEData[] → this method → GPU buffer
+   *
+   * Each TLE line-2 encodes: inclination, RAAN, eccentricity, arg of perigee,
+   * mean anomaly, and mean motion. We extract RAAN, inclination, and mean anomaly
+   * into the compact vec4f GPU format. The shell index is inferred from altitude.
+   *
+   * If tleCount < NUM_SATELLITES, the remaining slots are filled deterministically
+   * with procedural Walker satellites (same as generateOrbitalElements) so the
+   * compute shader always processes a full 1,048,576-element buffer.
+   *
+   * @param tles - Parsed TLE records from TLELoader.parse()
+   * @returns Number of real TLE satellites loaded (before padding)
+   */
+  loadFromTLEData(tles: TLEData[]): number {
+    const startTime = performance.now();
+    const tleCount = Math.min(tles.length, this.numSatellites);
+
+    console.log(`[SatelliteGPUBuffer] Loading ${tleCount} TLE satellites...`);
+
+    for (let t = 0; t < tleCount; t++) {
+      const { line2 } = tles[t];
+      // TLE line-2 format (fixed-width columns):
+      //   col 9-16:  inclination (deg)
+      //   col 18-25: RAAN (deg)
+      //   col 27-33: eccentricity (leading decimal point implied)
+      //   col 35-42: argument of perigee (deg)
+      //   col 44-51: mean anomaly (deg)
+      //   col 53-63: mean motion (rev/day)
+      const incDeg = parseFloat(line2.substring(8, 16).trim());
+      const raanDeg = parseFloat(line2.substring(17, 25).trim());
+      const meanAnomalyDeg = parseFloat(line2.substring(43, 51).trim());
+      const meanMotionRevPerDay = parseFloat(line2.substring(52, 63).trim());
+
+      const DEG_TO_RAD = Math.PI / 180;
+      const raan = raanDeg * DEG_TO_RAD;
+      const inc = incDeg * DEG_TO_RAD;
+      const M = meanAnomalyDeg * DEG_TO_RAD;
+
+      // Derive altitude from mean motion: n(rad/s) = meanMotion * 2π / 86400
+      // a = (μ / n²)^(1/3), altitude = a - R_earth
+      const nRadPerSec = meanMotionRevPerDay * 2 * Math.PI / 86400;
+      const MU = 398600.4418;
+      const a = Math.pow(MU / (nRadPerSec * nRadPerSec), 1 / 3);
+      const altKm = a - 6371.0;
+
+      // Classify into shell by altitude
+      let shellIndex: number;
+      if (altKm < 450) {
+        shellIndex = 0; // low shell (~340 km)
+      } else if (altKm < 800) {
+        shellIndex = 1; // mid shell (~550 km)
+      } else {
+        shellIndex = 2; // high shell (~1150 km)
+      }
+
+      const shellColors = [2.0, 6.0, 3.0]; // Blue, White, Gold
+      const colorIndex = shellColors[shellIndex];
+      const shellData = (shellIndex << 8) | (colorIndex & 0xFF);
+
+      const idx = t * 4;
+      this.orbitalElementData[idx + 0] = raan;
+      this.orbitalElementData[idx + 1] = inc;
+      this.orbitalElementData[idx + 2] = M;
+      this.orbitalElementData[idx + 3] = shellData;
+    }
+
+    // Fill remaining slots with deterministic procedural Walker satellites.
+    // Uses the same distribution as generateOrbitalElements but with a fixed
+    // seed (no Math.random) so results are reproducible.
+    if (tleCount < this.numSatellites) {
+      const remaining = this.numSatellites - tleCount;
+      console.log(`[SatelliteGPUBuffer] Padding ${remaining.toLocaleString()} remaining slots with procedural Walker data`);
+
+      const { NUM_PLANES, SATELLITES_PER_PLANE } = CONSTANTS;
+      const shells = INCLINATION_SHELLS;
+
+      for (let j = 0; j < remaining; j++) {
+        const globalIdx = tleCount + j;
+        const plane = globalIdx % NUM_PLANES;
+        const sat = Math.floor(globalIdx / NUM_PLANES) % SATELLITES_PER_PLANE;
+
+        const raan = (plane / NUM_PLANES) * Math.PI * 2;
+        const shellIdx = Math.floor(plane / (NUM_PLANES / shells.length));
+        const inclination = shells[shellIdx];
+        const meanAnomaly = (sat / SATELLITES_PER_PLANE) * Math.PI * 2;
+
+        // Deterministic shell assignment based on global index
+        const shellIndex = globalIdx % 3 === 0 ? 0 : globalIdx % 3 === 1 ? 1 : 2;
+        const shellColors = [2.0, 6.0, 3.0];
+        const colorIndex = shellColors[shellIndex];
+        const shellData = (shellIndex << 8) | (colorIndex & 0xFF);
+
+        const idx = globalIdx * 4;
+        this.orbitalElementData[idx + 0] = raan;
+        this.orbitalElementData[idx + 1] = inclination;
+        this.orbitalElementData[idx + 2] = meanAnomaly;
+        this.orbitalElementData[idx + 3] = shellData;
+      }
+    }
+
+    const elapsed = performance.now() - startTime;
+    console.log(`[SatelliteGPUBuffer] TLE load complete in ${elapsed.toFixed(2)}ms (${tleCount} real + ${this.numSatellites - tleCount} procedural)`);
+    return tleCount;
   }
 
   /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,8 +12,24 @@ import { UIManager } from '@/ui/UIManager.js';
 import { PerformanceProfiler } from '@/utils/PerformanceProfiler.js';
 import { genSphere, extractFrustum } from '@/utils/math.js';
 import { CONSTANTS, RENDER, CAMERA, BUFFER_SIZES } from '@/types/constants.js';
+import { TLELoader } from '@/data/TLELoader.js';
 
 import './styles.css';
+
+/**
+ * Known CelesTrak group names for the ?tle= query param shorthand.
+ * Usage: ?tle=starlink or ?tle=https://example.com/my-tles.txt
+ */
+const CELESTRAK_GROUPS: Record<string, string> = {
+  starlink: 'starlink',
+  oneweb: 'oneweb',
+  iridium: 'iridium',
+  'iridium-next': 'iridium-NEXT',
+  gps: 'gps-ops',
+  galileo: 'galileo',
+  stations: 'stations',
+  active: 'active',
+};
 
 /**
  * Main Application Class
@@ -122,6 +138,35 @@ class GrokZephyrApp {
   }
 
   /**
+   * Resolve the TLE data source from the query string.
+   *
+   * Supports:
+   *   ?tle=starlink       → CelesTrak Starlink group
+   *   ?tle=oneweb         → CelesTrak OneWeb group
+   *   ?tle=https://...    → arbitrary URL returning 3-line TLE text
+   *
+   * Returns null if no ?tle param is present (uses default procedural mode).
+   */
+  private getTLESource(): string | null {
+    const params = new URLSearchParams(window.location.search);
+    const tleParam = params.get('tle');
+    if (!tleParam) return null;
+
+    const lower = tleParam.toLowerCase();
+    if (CELESTRAK_GROUPS[lower]) {
+      return `https://celestrak.org/NORAD/elements/gp.php?GROUP=${CELESTRAK_GROUPS[lower]}&FORMAT=tle`;
+    }
+
+    // Treat as a direct URL if it starts with http(s)
+    if (tleParam.startsWith('http://') || tleParam.startsWith('https://')) {
+      return tleParam;
+    }
+
+    // Otherwise treat as a CelesTrak group name (best-effort)
+    return `https://celestrak.org/NORAD/elements/gp.php?GROUP=${encodeURIComponent(tleParam)}&FORMAT=tle`;
+  }
+
+  /**
    * Set beam pattern mode (0=chaos, 1=GROK, 2=X logo)
    */
   setPatternMode(mode: number): void {
@@ -165,9 +210,31 @@ class GrokZephyrApp {
       // Initialize buffers
       this.buffers = new SatelliteGPUBuffer(this.context);
       const bufferSet = this.buffers.initialize();
-      
-      // Generate and upload orbital elements
-      this.buffers.generateOrbitalElements();
+
+      // Load orbital data: TLE if requested via query param, else procedural Walker
+      const tleSource = this.getTLESource();
+      let dataSourceLabel = 'Procedural Walker';
+      let realTLECount = 0;
+
+      if (tleSource) {
+        try {
+          console.log(`[GrokZephyr] Loading TLE data from: ${tleSource}`);
+          const tles = await TLELoader.fromFile(tleSource);
+          if (tles.length > 0) {
+            realTLECount = this.buffers.loadFromTLEData(tles);
+            dataSourceLabel = `TLE (${realTLECount.toLocaleString()} real)`;
+            console.log(`[GrokZephyr] Loaded ${realTLECount} TLE satellites, padded to ${CONSTANTS.NUM_SATELLITES.toLocaleString()}`);
+          } else {
+            console.warn('[GrokZephyr] TLE source returned 0 records, falling back to procedural');
+            this.buffers.generateOrbitalElements();
+          }
+        } catch (err) {
+          console.warn('[GrokZephyr] TLE fetch/parse failed, falling back to procedural generation:', err);
+          this.buffers.generateOrbitalElements();
+        }
+      } else {
+        this.buffers.generateOrbitalElements();
+      }
       this.buffers.uploadOrbitalElements();
       
       // Create Earth geometry
@@ -185,6 +252,7 @@ class GrokZephyrApp {
       
       // Update UI
       this.ui.setFleetCount(CONSTANTS.NUM_SATELLITES);
+      this.ui.setDataSource(dataSourceLabel);
       this.ui.hideError();
       
       // Set initial view mode

--- a/src/ui/UIManager.ts
+++ b/src/ui/UIManager.ts
@@ -132,6 +132,21 @@ export class UIManager {
   }
 
   /**
+   * Display the orbital data source (procedural or TLE).
+   * Shown below the fleet count in the HUD.
+   */
+  setDataSource(label: string): void {
+    let el = document.getElementById('s-datasrc');
+    if (!el) {
+      el = document.createElement('div');
+      el.id = 's-datasrc';
+      el.className = 'stat';
+      this.elements.fleet.parentElement?.insertBefore(el, this.elements.fleet.nextSibling);
+    }
+    el.textContent = `Source   : ${label}`;
+  }
+
+  /**
    * Update all stats from performance data
    */
   updateStats(stats: PerformanceStats): void {


### PR DESCRIPTION
Adds ?tle= query parameter support to load real satellite TLE data:
- ?tle=starlink loads from CelesTrak Starlink group
- ?tle=https://... loads from arbitrary TLE URL
- Without ?tle=, default procedural Walker constellation is used

Changes:
- SatelliteGPUBuffer: add loadFromTLEData() that parses TLE line2 fixed-width columns, derives shell from altitude, packs into the existing vec4f GPU format, and fills remaining slots with procedural Walker satellites
- main.ts: read ?tle= param, resolve CelesTrak shorthands or direct URLs, attempt TLE load with fallback to procedural on failure
- UIManager: add setDataSource() to display data origin in HUD
- AGENTS.md: document TLE mode activation, data flow, and caveats

If TLE fetch/parse fails, logs a warning and falls back silently to procedural generation. Startup robustness is preserved.

https://claude.ai/code/session_01HrfE7H2iuaEsiam1qBZjpy