### PR TITLE
Fix WGSL shader syntax error: replace ternary operator with select

### DIFF
--- a/src/shaders/render/beam.ts
+++ b/src/shaders/render/beam.ts
@@ -47,7 +47,7 @@ fn vs(@builtin(vertex_index) vi: u32, @builtin(instance_index) instance: u32) ->
   let worldPos = center + offsetDir * sideSign * thickness;
 
   out.cp = uni.view_proj * vec4f(worldPos, 1.0);
-  out.uv = vec2f(t, (sideSign > 0.0) ? 1.0 : 0.0);
+  out.uv = vec2f(t, select(0.0, 1.0, sideSign > 0.0));
   out.intensity = start.w;
   out.mode = end.w;
   return out;


### PR DESCRIPTION
## Fix WGSL Shader Parsing Error

### Problem
The beam-render shader was failing to compile with:
```
Error while parsing WGSL: :61:38 error: invalid character found
  out.uv = vec2f(t, (sideSign > 0.0) ? 1.0 : 0.0);
                                     ^
```

### Root Cause
WGSL does not support the ternary operator (`condition ? trueValue : falseValue`) syntax. This is a C-like construct that isn't part of the WGSL specification.

### Solution
Replaced the ternary operator with WGSL's `select()` function, which has the signature:
```wgsl
select(falseValue, trueValue, condition)
```

**Changed:**
```wgsl
out.uv = vec2f(t, (sideSign > 0.0) ? 1.0 : 0.0);
```

**To:**
```wgsl
out.uv = vec2f(t, select(0.0, 1.0, sideSign > 0.0));
```

### Files Modified
- `src/shaders/render/beam.ts` - Fixed ternary operator in vertex shader

### Testing
The shader should now compile successfully without WGSL parsing errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KnT4KZWe5GxSfDJii6HKHk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized beam shader rendering for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->