### PR TITLE
Add Skyline view mode: night-city skyscraper rooftop observer

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,7 @@
        <button class="vbtn" id="btn2" aria-label="Switch to Fleet POV" title="Fleet POV - Satellite perspective with WASD controls">FLEET POV</button>
        <button class="vbtn" id="btn3" aria-label="Switch to Ground View" title="Ground View - Preset ground observer frames">GROUND VIEW</button>
        <button class="vbtn" id="btn4" aria-label="Switch to Moon View" title="Moon View - View from lunar orbit">MOON VIEW</button>
+       <button class="vbtn" id="btn5" aria-label="Switch to Skyline view" title="Skyline - Observer in a high-rise overlooking the city">SKYLINE</button>
       </div>
       <div class="view-extra-row">
        <button class="vbtn" id="btnDemo" data-no-interrupt-demo="true" aria-label="Start cinematic demo" title="Cinematic Demo - Automatically zoom and rotate">CINEMATIC DEMO</button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -345,6 +345,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -362,6 +380,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -377,6 +413,24 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -583,9 +637,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -603,9 +654,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -623,9 +671,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -643,9 +688,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -663,9 +705,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -683,9 +722,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1583,9 +1619,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1607,9 +1640,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1631,9 +1661,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1655,9 +1682,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2183,6 +2207,420 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/vitest/node_modules/@vitest/mocker": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
@@ -2208,6 +2646,50 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/vitest/node_modules/vite": {

--- a/src/audio/AudioEngine.ts
+++ b/src/audio/AudioEngine.ts
@@ -14,6 +14,7 @@ const AMBIENT_PROFILES: Record<ViewMode, AmbientProfile> = {
   'sat-pov':     { droneHz: 76, textureHz: 0.22, noiseCutoffHz: 620, textureGain: 0.24 },
   ground:        { droneHz: 66, textureHz: 0.16, noiseCutoffHz: 1100, textureGain: 0.28 },
   moon:          { droneHz: 49, textureHz: 0.06, noiseCutoffHz: 260, textureGain: 0.14 },
+  skyline:       { droneHz: 62, textureHz: 0.14, noiseCutoffHz: 900, textureGain: 0.24 },
 };
 
 /**

--- a/src/camera/CameraController.ts
+++ b/src/camera/CameraController.ts
@@ -590,7 +590,7 @@ export class CameraController {
       Math.sin(pitch),
     ];
 
-    const worldUp: Vec3 = this.currentMode === 'ground'
+    const worldUp: Vec3 = this.currentMode === 'ground' || this.currentMode === 'skyline'
       ? [Math.cos(yaw), Math.sin(yaw), 0]
       : [0, 0, 1];
 
@@ -607,8 +607,10 @@ export class CameraController {
       return camera;
     }
 
-    if (this.currentMode === 'ground') {
-      const surfaceRadius = CONSTANTS.EARTH_RADIUS_KM + 0.1;
+    if (this.currentMode === 'ground' || this.currentMode === 'skyline') {
+      const surfaceRadius = this.currentMode === 'skyline'
+        ? CONSTANTS.EARTH_RADIUS_KM + 0.18
+        : CONSTANTS.EARTH_RADIUS_KM + 0.1;
       const pannedPosition = v3add(camera.position, this.panOffset);
       const newPosition = v3scale(v3norm(pannedPosition), surfaceRadius);
 
@@ -671,6 +673,11 @@ export class CameraController {
       case 4:
         this.currentMode = 'moon';
         break;
+      case 5:
+        this.currentMode = 'skyline';
+        this.cameraAngles.pitch = 0;
+        this.cameraAngles.yaw = 0;
+        break;
       default:
         this.currentMode = 'horizon-720';
     }
@@ -709,6 +716,8 @@ export class CameraController {
     if ((from === 'sat-pov' && to === 'ground') || (from === 'ground' && to === 'sat-pov')) return 0.7;
     // God ↔ horizon: medium arc
     if ((from === 'god' && to === 'horizon-720') || (from === 'horizon-720' && to === 'god')) return 0.8;
+    // Ground ↔ skyline: both surface-anchored, near-instant transition
+    if ((from === 'ground' && to === 'skyline') || (from === 'skyline' && to === 'ground')) return 0.5;
     // Any remaining pair
     return 1.0;
   }
@@ -855,6 +864,8 @@ export class CameraController {
         return this.calculateGroundView();
       case 'moon':
         return this.calculateMoonView();
+      case 'skyline':
+        return this.calculateSkylineView();
       default:
         return this.calculateHorizonView();
     }
@@ -1448,7 +1459,53 @@ export class CameraController {
     
     // Up is radial from Earth center
     const up: Vec3 = v3norm(position);
-    
+
+    return {
+      position,
+      target,
+      up,
+      fov: CAMERA.DEFAULT_FOV,
+      near: 0.1,
+      far: CAMERA.FAR_PLANE,
+    };
+  }
+
+  /**
+   * Skyline View
+   *
+   * Observer high in a building, looking out over a procedural night city.
+   * Mirrors calculateGroundView() but lifted further off the surface and
+   * biased to look slightly downward at the skyline by default.
+   */
+  private calculateSkylineView(): CameraState {
+    const yaw = this.cameraAngles.yaw * MATH.DEG_TO_RAD;
+    const pitch = this.cameraAngles.pitch * MATH.DEG_TO_RAD;
+
+    // Lifted higher than ground view to sit above the rooftops.
+    const liftKm = 0.18;
+    const surfaceRadius = CONSTANTS.EARTH_RADIUS_KM + liftKm;
+
+    const position: Vec3 = [
+      surfaceRadius * Math.cos(yaw),
+      surfaceRadius * Math.sin(yaw),
+      0
+    ];
+
+    // Bias the default look direction ~8° downward toward the skyline.
+    const downwardBiasRad = 8 * MATH.DEG_TO_RAD;
+    const lookPitch = -(pitch + downwardBiasRad);
+
+    const cosP = Math.cos(lookPitch);
+    const sinP = Math.sin(lookPitch);
+
+    const target: Vec3 = [
+      position[0] + Math.cos(yaw) * cosP * 10000,
+      position[1] + Math.sin(yaw) * cosP * 10000,
+      position[2] + sinP * 10000
+    ];
+
+    const up: Vec3 = v3norm(position);
+
     return {
       position,
       target,

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,8 @@ import { FocusManager, type ConstellationStats, type FocusSelection } from '@/fo
 import { AudioEngine } from '@/audio/AudioEngine.js';
 import { TrailRenderer } from '@/render/TrailRenderer.js';
 import { EarthAtmosphereRenderer } from '@/earth.js';
-import { genSphere, extractFrustum, mat4inv } from '@/utils/math.js';
+import { SkylineCity } from '@/render/SkylineCity.js';
+import { genSphere, extractFrustum, mat4inv, v3norm, v3dot, smoothstep } from '@/utils/math.js';
 import { getBeamPatternTitle } from '@/patterns.js';
 import { CONSTANTS, BUFFER_SIZES, UI as UI_CONSTANTS } from '@/types/constants.js';
 import { TLELoader } from '@/data/TLELoader.js';
@@ -147,6 +148,7 @@ class GrokZephyrApp {
   private focusManager: FocusManager | null = null;
   private trailRenderer: TrailRenderer | null = null;
   private earthAtmosphereRenderer: EarthAtmosphereRenderer | null = null;
+  private skyline: SkylineCity = new SkylineCity();
   private groundViewEnabled = true;
   private selectedSatelliteIndex = -1;
   private patternSeed = 0;
@@ -490,13 +492,17 @@ class GrokZephyrApp {
   private updateGroundObserverOverlay(): void {
     const overlay = document.getElementById('ground-observer-overlay');
     const presetSelector = document.getElementById('ground-preset-selector');
-    const isGround = this.camera.getViewMode() === 'ground';
+    const viewMode = this.camera.getViewMode();
+    const isGround = viewMode === 'ground';
+    const isSkyline = viewMode === 'skyline';
 
-    if (overlay) overlay.style.display = isGround ? 'block' : 'none';
+    if (overlay) overlay.style.display = (isGround || isSkyline) ? 'block' : 'none';
     if (presetSelector) presetSelector.style.display = isGround ? 'flex' : 'none';
 
     if (isGround) {
       this.applyGroundOverlayClass(this.groundObserver.getOverlayClass());
+    } else if (isSkyline) {
+      this.applyGroundOverlayClass('frame-skyline');
     }
   }
 
@@ -552,6 +558,7 @@ class GrokZephyrApp {
       case 'sat-pov': return 'Fleet POV';
       case 'ground': return 'Ground View';
       case 'moon': return 'Moon View';
+      case 'skyline': return 'Skyline View';
       default: return 'Unknown';
     }
   }
@@ -1298,7 +1305,7 @@ class GrokZephyrApp {
     };
 
     return {
-      viewMode:     parseIntParam('mode',    0, 4),
+      viewMode:     parseIntParam('mode',    0, 5),
       qualityLevel: parseQualityParam(params.get('preset')),
       physicsMode:  parseIntParam('physics', 0, 2),
       patternMode:  parseIntParam('pattern', 0, 2),
@@ -1388,6 +1395,10 @@ class GrokZephyrApp {
       this.pipeline.initialize(width, height);
       this.buffers.updateBloomUniforms(width, height);
       window.addEventListener('resize', this.resizeListener);
+
+      // Skyline city: separate near-tuned pass, its own GPU buffers.
+      this.skyline.createBuffers(this.context.getDevice());
+      this.pipeline.setSkylineResources(this.skyline.getCityUniformBuffer(), this.skyline.getInstanceBuffer());
 
       // Initialize PostProcessStack — operates in "skip-final-tonemap" mode so it
       // acts as a post-composite TAA + color-grading layer without double-tonemapping.
@@ -1990,7 +2001,27 @@ class GrokZephyrApp {
       this.volumetricBeamRenderer.encodeRaymarchPass(encoder);
       this.volumetricBeamRenderer.encodeCompositePass(encoder, this.pipeline.getHDRView());
     }
-    
+
+    // Pass 2.7: Skyline city — separate near-tuned pass, own depth clear.
+    // Does not touch the global frustum or the scene pass draw order above.
+    if (this.camera.getViewMode() === 'skyline' && this.context) {
+      this.skyline.setObserver(cameraState.position);
+      const { width: canvasW, height: canvasH } = this.context.getCanvasSize();
+      const cityViewProj = this.skyline.computeCityViewProj(
+        cameraState.position,
+        cameraState.target,
+        cameraState.up,
+        canvasW / canvasH,
+        cameraState.fov
+      );
+      const sunPos = this.calculateSunPosition(this.simTime);
+      const sunDir = v3norm(sunPos);
+      const up = v3norm(cameraState.position);
+      const nightFactor = smoothstep(0.10, -0.10, v3dot(up, sunDir));
+      this.skyline.updateUniform(this.context.getDevice(), cityViewProj, sunDir, nightFactor, this.simTime);
+      this.pipeline.encodeSkylinePass(encoder, this.skyline.buildingCount);
+    }
+
     const sceneSourceView = this.pipeline.encodeDepthOfFieldPasses(encoder);
     const motionBlurSourceView = this.pipeline.encodeMotionBlurPass(encoder, sceneSourceView);
     this.pipeline.encodeAutoExposurePasses(encoder, motionBlurSourceView, deltaTime);
@@ -2184,6 +2215,7 @@ class GrokZephyrApp {
     this.pipeline?.destroy();
     this.postProcessStack?.destroy();
     this.volumetricBeamRenderer?.destroy();
+    this.skyline.destroy();
     this.buffers?.destroy();
     this.context?.destroy();
     this.profiler.destroy();

--- a/src/render/RenderPipeline.ts
+++ b/src/render/RenderPipeline.ts
@@ -78,6 +78,7 @@ export interface Pipelines {
   satellites: GPURenderPipeline;
   beam: GPURenderPipeline;
   groundTerrain: GPURenderPipeline;
+  skyline: GPURenderPipeline;
   bloomThreshold: GPURenderPipeline;
   bloomBlur: GPURenderPipeline;
   bloomDownsample: GPURenderPipeline;
@@ -216,6 +217,9 @@ export class RenderPipeline {
   private motionBlurHistoryReady = false;
   private atmosphereLUT: GPUTexture | null = null;
   private atmosphereLUTView: GPUTextureView | null = null;
+
+  /** Bind group for the skyline city pass (Uni + CityUni + buildings storage). */
+  private skylineBindGroup: GPUBindGroup | null = null;
 
   /** Maximum supported pyramid levels */
   private static readonly MAX_BLOOM_LEVELS = 5;
@@ -369,6 +373,15 @@ export class RenderPipeline {
         { binding: 1, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: 'float' } },
         { binding: 2, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' } },
         { binding: 3, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'uniform' } },
+      ],
+    });
+
+    // Skyline city layout: shared Uni + CityUni + read-only buildings storage
+    const skylineLayout = device.createBindGroupLayout({
+      entries: [
+        { binding: 0, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT, buffer: { type: 'uniform' } },
+        { binding: 1, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT, buffer: { type: 'uniform' } },
+        { binding: 2, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT, buffer: { type: 'read-only-storage' } },
       ],
     });
 
@@ -581,6 +594,25 @@ export class RenderPipeline {
           format: RENDER.DEPTH_FORMAT,
           depthWriteEnabled: false,
           depthCompare: 'always',
+        },
+      }),
+
+      skyline: device.createRenderPipeline({
+        layout: device.createPipelineLayout({ bindGroupLayouts: [skylineLayout] }),
+        vertex: {
+          module: this.context.createShaderModule(SHADERS.render.skyline, 'skyline-city'),
+          entryPoint: 'vs',
+        },
+        fragment: {
+          module: this.context.createShaderModule(SHADERS.render.skyline, 'skyline-city'),
+          entryPoint: 'fs',
+          targets: [{ format: RENDER.HDR_FORMAT }],
+        },
+        primitive: { topology: 'triangle-list', cullMode: 'none' },
+        depthStencil: {
+          format: RENDER.DEPTH_FORMAT,
+          depthWriteEnabled: true,
+          depthCompare: 'less',
         },
       }),
 
@@ -1128,6 +1160,58 @@ export class RenderPipeline {
     pass.setBindGroup(0, this.bindGroups.beam);
     pass.draw(4, MAX_BEAMS);
 
+    pass.end();
+  }
+
+  /**
+   * Lazily build the bind group for the skyline city pass.
+   * Called once the SkylineCity's GPU buffers exist.
+   */
+  setSkylineResources(cityUniformBuffer: GPUBuffer, instanceBuffer: GPUBuffer): void {
+    if (!this.pipelines) return;
+    if (this.skylineBindGroup) return;
+
+    const device = this.context.getDevice();
+    this.skylineBindGroup = device.createBindGroup({
+      layout: this.pipelines.skyline.getBindGroupLayout(0),
+      entries: [
+        { binding: 0, resource: { buffer: this.buffers.uniforms } },
+        { binding: 1, resource: { buffer: cityUniformBuffer } },
+        { binding: 2, resource: { buffer: instanceBuffer } },
+      ],
+    });
+  }
+
+  /**
+   * Execute the skyline city pass: instanced extruded-box buildings drawn
+   * into the shared HDR target with their own near-tuned projection.
+   *
+   * Loads (rather than clears) the HDR color so the buildings layer on top
+   * of whatever the scene pass already rendered, but uses a FRESH depth
+   * clear and its own near/far range — the city is sub-kilometer in scale
+   * and must not share the global planetary frustum's depth precision.
+   */
+  encodeSkylinePass(encoder: GPUCommandEncoder, buildingCount: number): void {
+    if (!this.pipelines || !this.renderTargets || !this.skylineBindGroup) return;
+
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [{
+        view: this.renderTargets.hdrView,
+        loadOp: 'load',
+        storeOp: 'store',
+      }],
+      depthStencilAttachment: {
+        view: this.renderTargets.depthView,
+        depthClearValue: 1,
+        depthLoadOp: 'clear',
+        depthStoreOp: 'store',
+      },
+    });
+
+    pass.setViewport(0, 0, this.width, this.height, 0, 1);
+    pass.setPipeline(this.pipelines.skyline);
+    pass.setBindGroup(0, this.skylineBindGroup);
+    pass.draw(36, buildingCount);
     pass.end();
   }
 

--- a/src/render/SkylineCity.ts
+++ b/src/render/SkylineCity.ts
@@ -1,0 +1,228 @@
+/**
+ * Skyline City
+ *
+ * Deterministic procedural night-city generator for the 'skyline' view mode.
+ * Buildings live in a local East/North/Up (ENU) frame anchored at the
+ * observer's surface point, kept in kilometers, so the sub-kilometer city
+ * geometry retains float32 precision independent of the planetary-scale ECI
+ * coordinates used everywhere else in the simulation.
+ */
+
+import type { Vec3 } from '@/types/index.js';
+import { v3norm, v3cross, v3sub, v3scale, v3dot, mat4lookAt, mat4persp, mat4mul } from '@/utils/math.js';
+
+/** Floats per Building instance (must match the 32-byte WGSL struct). */
+const BUILDING_FLOATS = 8;
+
+/** Bytes in the CityUni uniform (mat4x4f + vec4f + vec4f = 96 bytes). */
+const CITY_UNI_BYTES = 96;
+
+export interface SkylineConfig {
+  /** PRNG seed for deterministic, stable layout across frames. */
+  seed: number;
+  /** Number of instanced buildings. */
+  buildingCount: number;
+  /** Side length (km) of the square city footprint, centered on the observer. */
+  citySpanKm: number;
+  minHeightKm: number;
+  maxHeightKm: number;
+  minFootprintKm: number;
+  maxFootprintKm: number;
+  /** Radius (km) around the observer kept clear of buildings (the street below the window). */
+  streetClearanceKm: number;
+}
+
+export const DEFAULT_SKYLINE: SkylineConfig = {
+  seed: 0xc0ffee,
+  buildingCount: 260,
+  citySpanKm: 1.6,
+  minHeightKm: 0.03,
+  maxHeightKm: 0.32,
+  minFootprintKm: 0.018,
+  maxFootprintKm: 0.06,
+  streetClearanceKm: 0.05,
+};
+
+/** Deterministic 32-bit PRNG (mulberry32). */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return function (): number {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export class SkylineCity {
+  readonly buildingCount: number;
+
+  private config: SkylineConfig;
+  private buildingData: Float32Array;
+
+  private observerEci: Vec3 = [0, 0, 0];
+  private east: Vec3 = [1, 0, 0];
+  private north: Vec3 = [0, 1, 0];
+  private up: Vec3 = [0, 0, 1];
+  private observerSet = false;
+
+  private instanceBuffer: GPUBuffer | null = null;
+  private cityUniformBuffer: GPUBuffer | null = null;
+
+  constructor(config: Partial<SkylineConfig> = {}) {
+    this.config = { ...DEFAULT_SKYLINE, ...config };
+    this.buildingCount = this.config.buildingCount;
+    this.buildingData = new Float32Array(this.buildingCount * BUILDING_FLOATS);
+    this.generate();
+  }
+
+  /** Lay out the deterministic city footprint in local ENU (km). Runs once at construction. */
+  private generate(): void {
+    const rng = mulberry32(this.config.seed);
+    const half = this.config.citySpanKm / 2;
+
+    for (let i = 0; i < this.buildingCount; i++) {
+      const east = (rng() * 2 - 1) * half;
+      const north = (rng() * 2 - 1) * half;
+      const distFromObserver = Math.hypot(east, north);
+
+      const width = this.config.minFootprintKm + rng() * (this.config.maxFootprintKm - this.config.minFootprintKm);
+      const depth = this.config.minFootprintKm + rng() * (this.config.maxFootprintKm - this.config.minFootprintKm);
+      // Keep the street directly below the observer's window clear, and bias
+      // toward shorter buildings so the skyline reads as a real city, not a wall.
+      const height = distFromObserver < this.config.streetClearanceKm
+        ? 0
+        : this.config.minHeightKm + Math.pow(rng(), 1.5) * (this.config.maxHeightKm - this.config.minHeightKm);
+
+      const o = i * BUILDING_FLOATS;
+      this.buildingData[o + 0] = east;
+      this.buildingData[o + 1] = north;
+      this.buildingData[o + 2] = width;
+      this.buildingData[o + 3] = depth;
+      this.buildingData[o + 4] = height;
+      this.buildingData[o + 5] = rng();
+      this.buildingData[o + 6] = rng();
+      this.buildingData[o + 7] = 0;
+    }
+  }
+
+  /** Allocate the GPU storage/uniform buffers and upload the static instance data. */
+  createBuffers(device: GPUDevice): void {
+    this.instanceBuffer = device.createBuffer({
+      size: this.buildingData.byteLength,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+      label: 'Skyline Building Instances',
+    });
+    device.queue.writeBuffer(
+      this.instanceBuffer,
+      0,
+      this.buildingData.buffer as ArrayBuffer,
+      this.buildingData.byteOffset,
+      this.buildingData.byteLength
+    );
+
+    this.cityUniformBuffer = device.createBuffer({
+      size: CITY_UNI_BYTES,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+      label: 'Skyline City Uniform',
+    });
+  }
+
+  getInstanceBuffer(): GPUBuffer {
+    if (!this.instanceBuffer) throw new Error('SkylineCity.createBuffers() must be called first');
+    return this.instanceBuffer;
+  }
+
+  getCityUniformBuffer(): GPUBuffer {
+    if (!this.cityUniformBuffer) throw new Error('SkylineCity.createBuffers() must be called first');
+    return this.cityUniformBuffer;
+  }
+
+  /**
+   * Anchor the local ENU frame to the observer's current ECI position.
+   * Safe to call every frame; the building layout itself never changes.
+   */
+  setObserver(eciPosition: Vec3): void {
+    this.observerEci = eciPosition;
+    this.up = v3norm(eciPosition);
+    // The ground/skyline camera sits on the equatorial plane (z = 0), so
+    // world +Z is never parallel to `up` and is a stable "north" reference.
+    const worldZ: Vec3 = [0, 0, 1];
+    this.north = v3norm(v3sub(worldZ, v3scale(this.up, v3dot(worldZ, this.up))));
+    this.east = v3norm(v3cross(this.north, this.up));
+    this.observerSet = true;
+  }
+
+  /** Project a world ECI point into local ENU km coordinates relative to the observer. */
+  eciToEnu(point: Vec3): Vec3 {
+    const rel = v3sub(point, this.observerEci);
+    return [v3dot(rel, this.east), v3dot(rel, this.north), v3dot(rel, this.up)];
+  }
+
+  /**
+   * Build a near-tuned view-projection for the city pass: same eye/look
+   * direction as the main camera, but with a near/far range suited to
+   * sub-kilometer geometry instead of the planetary frustum.
+   */
+  computeCityViewProj(
+    cameraPosition: Vec3,
+    cameraTarget: Vec3,
+    cameraUp: Vec3,
+    aspect: number,
+    fov: number
+  ): Float32Array {
+    if (!this.observerSet) this.setObserver(cameraPosition);
+
+    const eyeEnu = this.eciToEnu(cameraPosition);
+    const targetEnu = this.eciToEnu(cameraTarget);
+    const upEnu: Vec3 = [
+      v3dot(cameraUp, this.east),
+      v3dot(cameraUp, this.north),
+      v3dot(cameraUp, this.up),
+    ];
+
+    const view = mat4lookAt(eyeEnu, targetEnu, v3norm(upEnu));
+    const projection = mat4persp(fov, aspect, 0.005, 60);
+    return mat4mul(projection, view);
+  }
+
+  /** Write the CityUni buffer for the upcoming skyline pass. */
+  updateUniform(
+    device: GPUDevice,
+    cityViewProj: Float32Array,
+    sunDirEci: Vec3,
+    nightFactor: number,
+    time: number
+  ): void {
+    if (!this.cityUniformBuffer) return;
+
+    const sunEnu = v3norm([
+      v3dot(sunDirEci, this.east),
+      v3dot(sunDirEci, this.north),
+      v3dot(sunDirEci, this.up),
+    ]);
+
+    const data = new ArrayBuffer(CITY_UNI_BYTES);
+    new Float32Array(data, 0, 16).set(cityViewProj);
+    const tail = new Float32Array(data, 64, 8);
+    tail[0] = sunEnu[0];
+    tail[1] = sunEnu[1];
+    tail[2] = sunEnu[2];
+    tail[3] = 0;
+    tail[4] = nightFactor;
+    tail[5] = this.buildingCount;
+    tail[6] = time;
+    tail[7] = 0;
+
+    device.queue.writeBuffer(this.cityUniformBuffer, 0, data);
+  }
+
+  destroy(): void {
+    this.instanceBuffer?.destroy();
+    this.cityUniformBuffer?.destroy();
+    this.instanceBuffer = null;
+    this.cityUniformBuffer = null;
+  }
+}
+
+export default SkylineCity;

--- a/src/shaders/render/index.ts
+++ b/src/shaders/render/index.ts
@@ -8,5 +8,6 @@ export { ATM_SHADER as atmosphere } from './atmosphere.js';
 export { SATELLITE_SHADER as satellites } from './satellites.js';
 export { BEAM_SHADER as beam } from './beam.js';
 export { GROUND_TERRAIN as ground } from './ground.js';
+export { SKYLINE_BUILDINGS as skyline } from './skyline.js';
 export { VOLUMETRIC_BEAM_SHADER as volumetricBeam } from './volumetricBeams.js';
 export * as postProcess from './postProcess/index.js';

--- a/src/shaders/render/skyline.ts
+++ b/src/shaders/render/skyline.ts
@@ -1,0 +1,115 @@
+/**
+ * Skyline City Shader
+ *
+ * Instanced extruded-box buildings rendered into the same HDR target as the
+ * main scene, using a separate near-tuned city view-projection (CityUni)
+ * rather than the global planetary frustum. Windows are an emissive grid
+ * faked procedurally per-face; no textures are sampled.
+ */
+
+import { UNIFORM_STRUCT } from '../uniforms.js';
+
+export const SKYLINE_BUILDINGS = UNIFORM_STRUCT + /* wgsl */ `
+struct Building {
+  posXZ      : vec2f, // local ENU position: x = east (km), y = north (km)
+  size       : vec2f, // footprint: width (east-west), depth (north-south), km
+  height     : f32,   // extrusion height, km
+  colorSeed  : f32,   // window tint variation seed
+  windowSeed : f32,   // window on/off pattern seed
+  pad        : f32,
+};
+
+struct CityUni {
+  city_view_proj : mat4x4f,
+  sun_dir_enu    : vec4f,
+  params         : vec4f, // x = nightFactor, y = buildingCount, z = time, w = pad
+};
+
+@group(0) @binding(1) var<uniform> city : CityUni;
+@group(0) @binding(2) var<storage, read> buildings : array<Building>;
+
+struct VOut {
+  @builtin(position) cp : vec4f,
+  @location(0) localUV  : vec2f,
+  @location(1) faceId   : f32,
+  @location(2) instSeed : vec2f,
+};
+
+const CUBE_POS = array<vec3f, 36>(
+  // -X (west)
+  vec3f(0.0, 0.0, 0.0), vec3f(0.0, 1.0, 0.0), vec3f(0.0, 1.0, 1.0),
+  vec3f(0.0, 0.0, 0.0), vec3f(0.0, 1.0, 1.0), vec3f(0.0, 0.0, 1.0),
+  // +X (east)
+  vec3f(1.0, 0.0, 0.0), vec3f(1.0, 0.0, 1.0), vec3f(1.0, 1.0, 1.0),
+  vec3f(1.0, 0.0, 0.0), vec3f(1.0, 1.0, 1.0), vec3f(1.0, 1.0, 0.0),
+  // -Y (south)
+  vec3f(0.0, 0.0, 0.0), vec3f(1.0, 0.0, 0.0), vec3f(1.0, 0.0, 1.0),
+  vec3f(0.0, 0.0, 0.0), vec3f(1.0, 0.0, 1.0), vec3f(0.0, 0.0, 1.0),
+  // +Y (north)
+  vec3f(0.0, 1.0, 0.0), vec3f(0.0, 1.0, 1.0), vec3f(1.0, 1.0, 1.0),
+  vec3f(0.0, 1.0, 0.0), vec3f(1.0, 1.0, 1.0), vec3f(1.0, 1.0, 0.0),
+  // -Z (bottom)
+  vec3f(0.0, 0.0, 0.0), vec3f(1.0, 1.0, 0.0), vec3f(0.0, 1.0, 0.0),
+  vec3f(0.0, 0.0, 0.0), vec3f(1.0, 0.0, 0.0), vec3f(1.0, 1.0, 0.0),
+  // +Z (roof)
+  vec3f(0.0, 0.0, 1.0), vec3f(0.0, 1.0, 1.0), vec3f(1.0, 1.0, 1.0),
+  vec3f(0.0, 0.0, 1.0), vec3f(1.0, 1.0, 1.0), vec3f(1.0, 0.0, 1.0)
+);
+
+fn hash21(p : vec2f) -> f32 {
+  let h = dot(p, vec2f(127.1, 311.7));
+  return fract(sin(h) * 43758.5453123);
+}
+
+@vertex
+fn vs(@builtin(vertex_index) vi : u32, @builtin(instance_index) ii : u32) -> VOut {
+  let b = buildings[ii];
+  let local = CUBE_POS[vi];
+  let faceId = f32(vi / 6u);
+
+  // East/North offset around the footprint center, Up extruded from the ground.
+  let worldX = b.posXZ.x + (local.x - 0.5) * b.size.x;
+  let worldY = b.posXZ.y + (local.y - 0.5) * b.size.y;
+  let worldZ = local.z * b.height;
+
+  var out : VOut;
+  out.cp = city.city_view_proj * vec4f(worldX, worldY, worldZ, 1.0);
+
+  // UVs span the perimeter (u) and height (v) for the side faces; unused for roof/floor.
+  let perimeterU = select(local.x * b.size.x, local.y * b.size.y, faceId > 1.5);
+  out.localUV = vec2f(perimeterU, worldZ);
+  out.faceId = faceId;
+  out.instSeed = vec2f(b.colorSeed, b.windowSeed);
+  return out;
+}
+
+@fragment
+fn fs(in : VOut) -> @location(0) vec4f {
+  // Roof (4) and floor (5) faces: flat dark rooftop concrete, no windows.
+  if (in.faceId > 3.5) {
+    return vec4f(0.018, 0.02, 0.026, 1.0);
+  }
+
+  // Window grid: ~6m floor pitch, ~4m window pitch along the facade.
+  let gridU = in.localUV.x / 4.0 + in.instSeed.x * 11.0;
+  let gridV = in.localUV.y / 6.0 + in.instSeed.y * 7.0;
+  let cellIdU = floor(gridU);
+  let cellIdV = floor(gridV);
+  let cellU = fract(gridU);
+  let cellV = fract(gridV);
+
+  let litRoll = hash21(vec2f(cellIdU, cellIdV) + in.instSeed * 13.0);
+  let isLit = step(0.55, litRoll);
+  let windowMask = step(0.18, cellU) * step(cellU, 0.82) * step(0.22, cellV) * step(cellV, 0.78);
+
+  let facadeColor = vec3f(0.028, 0.032, 0.045);
+  let warmWindow = vec3f(1.0, 0.74, 0.42);
+  let coolWindow = vec3f(0.55, 0.78, 1.0);
+  let windowTint = mix(warmWindow, coolWindow, hash21(in.instSeed + vec2f(3.1, 1.7)));
+
+  let emissive = isLit * windowMask * city.params.x;
+  let color = mix(facadeColor, windowTint * 2.4, emissive);
+
+  return vec4f(color, 1.0);
+}
+`;

--- a/src/styles/ground-observer.css
+++ b/src/styles/ground-observer.css
@@ -546,6 +546,64 @@
 }
 
 /* ============================================================================
+   SKYLINE WINDOW PRESET
+   ============================================================================ */
+
+.frame-skyline {
+  pointer-events: none;
+  /* Window frame borders, cooler/cleaner than the wood-toned house frame */
+  box-shadow:
+    inset 0 0 0 16px rgba(20, 24, 32, 0.92),
+    inset 0 0 0 18px rgba(8, 10, 16, 1),
+    inset 0 0 120px rgba(120, 180, 255, 0.08);
+}
+
+/* Stronger vignette + center mullion splitting the window into two panes */
+.frame-skyline::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background:
+    radial-gradient(
+      ellipse at center,
+      transparent 35%,
+      rgba(0, 0, 0, 0.5) 100%
+    ),
+    linear-gradient(
+      to right,
+      transparent calc(50% - 4px),
+      rgba(8, 10, 16, 0.95) calc(50% - 4px),
+      rgba(8, 10, 16, 0.95) calc(50% + 4px),
+      transparent calc(50% + 4px)
+    );
+  pointer-events: none;
+}
+
+/* Faint glass reflection sweep */
+.frame-skyline::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    115deg,
+    transparent 0%,
+    transparent 38%,
+    rgba(200, 220, 255, 0.05) 46%,
+    rgba(200, 220, 255, 0.08) 50%,
+    rgba(200, 220, 255, 0.05) 54%,
+    transparent 62%,
+    transparent 100%
+  );
+  pointer-events: none;
+}
+
+/* ============================================================================
    TRANSITION ANIMATIONS
    ============================================================================ */
 

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -39,6 +39,7 @@ export const VIEW_MODES: ViewModeConfig[] = [
   { id: 2, name: 'Fleet POV', altitude: '550', default: false },
   { id: 3, name: 'Ground View', altitude: '0', default: false },
   { id: 4, name: 'Moon View', altitude: '384400', default: false },
+  { id: 5, name: 'Skyline', altitude: '0', default: false },
 ] as const;
 
 /** Camera settings */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -50,7 +50,7 @@ export interface SatelliteState {
 }
 
 /** Camera view modes */
-export type ViewMode = 'horizon-720' | 'god' | 'sat-pov' | 'ground' | 'moon';
+export type ViewMode = 'horizon-720' | 'god' | 'sat-pov' | 'ground' | 'moon' | 'skyline';
 
 /** Camera pose configuration */
 export interface CameraPose {

--- a/src/ui/UIManager.ts
+++ b/src/ui/UIManager.ts
@@ -133,6 +133,7 @@ export class UIManager {
         document.getElementById('btn2') as HTMLButtonElement,
         document.getElementById('btn3') as HTMLButtonElement,
         document.getElementById('btn4') as HTMLButtonElement,
+        document.getElementById('btn5') as HTMLButtonElement,
       ],
       demoButton: document.getElementById('btnDemo') as HTMLButtonElement,
       demoAutoButton: document.getElementById('btnDemoAuto') as HTMLButtonElement,
@@ -964,6 +965,7 @@ export class UIManager {
             <button class="vbtn" id="btn2">FLEET POV</button>
             <button class="vbtn" id="btn3">GROUND VIEW</button>
             <button class="vbtn" id="btn4">MOON VIEW</button>
+            <button class="vbtn" id="btn5">SKYLINE</button>
           </div>
           <div class="view-extra-row">
             <button class="vbtn" id="btnDemo" data-no-interrupt-demo="true">CINEMATIC DEMO</button>


### PR DESCRIPTION
## Summary
- Adds a new `skyline` view mode: an observer high in a building looking out a window over a deterministic procedural night city, with the existing Colossus satellite constellation/streaks still visible crossing the sky above.
- New `SkylineCity` class generates a fixed building layout (mulberry32 PRNG, seeded) in a local East/North/Up frame anchored at the observer's surface point, kept in kilometers for float32 precision at sub-kilometer city scale.
- New instanced WGSL shader (`skyline.ts`) renders extruded box buildings with flat roofs and a procedural emissive window grid that lights up as a function of night factor.
- The city renders in its own pass with its own near-tuned view-projection (0.005–60 km) and its own depth clear, layered on top of the existing scene pass — the existing scene pass draw order and global planetary frustum are untouched.
- Wires the new mode through `CameraController` (mode switch, transition duration, pan/world-up handling, `calculateSkylineView()`), the UI view-mode picker (new `SKYLINE` button), ambient audio profile, and a CSS window-frame overlay (vignette, center mullion, faint glass reflection) matching the existing `.frame-house`/`.frame-rooftop` preset pattern.

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run build` passes
- [x] Verified with `?renderer=webgpu&mode=5` in headless Chromium: skyline shader/pipeline initialize cleanly alongside the rest of the pipeline with no shader or bind-group errors (confirmed identical environment-level swiftshader device-loss behavior occurs with the default mode too, so it is unrelated to this change)
- [x] Verified `?renderer=webgl&mode=5` does not crash or throw (WebGL2 fallback leaves skyline unimplemented but degrades gracefully)
- [ ] Manual visual check in a real GPU browser (not possible in this sandboxed environment)


---
_Generated by [Claude Code](https://claude.ai/code/session_011ruATrU9jQFX1eqQ16Xfwr)_