### PR TITLE
Ground View: replace flat gradient with ray-traced procedural horizon

### DIFF
--- a/src/camera/GroundObserverCamera.ts
+++ b/src/camera/GroundObserverCamera.ts
@@ -44,6 +44,23 @@ export interface GroundObserverConfig {
   };
   /** Atmospheric scattering multiplier */
   atmosphericScatter: number;
+  /** Horizon rendering bias for the ground terrain pass */
+  horizon: {
+    /** >0 sinks terrain toward ocean at the horizon (beach shimmer) */
+    oceanBias: number;
+    /** Night city-light glow strength near the horizon (rooftop urban glow) */
+    urbanGlow: number;
+    /** How much the terrain pass fades where the CSS frame overlay covers it */
+    overlayFade: number;
+  };
+}
+
+/** Params consumed by RenderPipeline.setGroundViewParams */
+export interface GroundHorizonSettings {
+  oceanBias: number;
+  urbanGlow: number;
+  overlayFade: number;
+  hazeBoost: number;
 }
 
 /** Preset configurations */
@@ -65,6 +82,7 @@ export const GROUND_OBSERVER_PRESETS: Record<GroundObserverPreset, GroundObserve
       strength: 0.02,
     },
     atmosphericScatter: 1.0,
+    horizon: { oceanBias: 0.0, urbanGlow: 0.35, overlayFade: 0.85 },
   },
 
   [GroundObserverPreset.CAR_WINDSHIELD]: {
@@ -85,6 +103,7 @@ export const GROUND_OBSERVER_PRESETS: Record<GroundObserverPreset, GroundObserve
       strength: 0.08,
     },
     atmosphericScatter: 0.8,
+    horizon: { oceanBias: 0.0, urbanGlow: 0.5, overlayFade: 0.85 },
   },
 
   [GroundObserverPreset.BEACH_NIGHT]: {
@@ -104,6 +123,7 @@ export const GROUND_OBSERVER_PRESETS: Record<GroundObserverPreset, GroundObserve
       strength: 0,
     },
     atmosphericScatter: 1.2,
+    horizon: { oceanBias: 0.3, urbanGlow: 0.12, overlayFade: 0.15 },
   },
 
   [GroundObserverPreset.ROOFTOP]: {
@@ -123,6 +143,7 @@ export const GROUND_OBSERVER_PRESETS: Record<GroundObserverPreset, GroundObserve
       strength: 0.03,
     },
     atmosphericScatter: 1.5,
+    horizon: { oceanBias: -0.06, urbanGlow: 1.0, overlayFade: 0.35 },
   },
 
   [GroundObserverPreset.AIRPLANE_WINDOW]: {
@@ -142,6 +163,7 @@ export const GROUND_OBSERVER_PRESETS: Record<GroundObserverPreset, GroundObserve
       strength: 0,
     },
     atmosphericScatter: 0.5,
+    horizon: { oceanBias: 0.05, urbanGlow: 0.45, overlayFade: 0.4 },
   },
 };
 
@@ -269,6 +291,14 @@ export class GroundObserverCamera {
   /** Get atmospheric scattering multiplier */
   getAtmosphericScatter(): number {
     return this.config.atmosphericScatter;
+  }
+
+  /** Get the horizon params for the ground terrain pass (preset-aware) */
+  getHorizonSettings(): GroundHorizonSettings {
+    return {
+      ...this.config.horizon,
+      hazeBoost: this.config.atmosphericScatter,
+    };
   }
 
   /** Cycle to next preset */

--- a/src/main.ts
+++ b/src/main.ts
@@ -156,7 +156,6 @@ class GrokZephyrApp {
   private trailRenderer: TrailRenderer | null = null;
   private earthAtmosphereRenderer: EarthAtmosphereRenderer | null = null;
   private skyline: SkylineCity = new SkylineCity();
-  private groundViewEnabled = true;
   private selectedSatelliteIndex = -1;
   private patternSeed = 0;
   private patternAnimationStart = 0;
@@ -1029,8 +1028,8 @@ class GrokZephyrApp {
   }
 
   setGroundViewEnabled(enabled: boolean): void {
-    this.groundViewEnabled = enabled;
     this.earthAtmosphereRenderer?.setEnabled(enabled);
+    this.pipeline?.setGroundTerrainEnabled(enabled);
   }
 
   private writePatternParamsBuffer(): void {
@@ -2059,14 +2058,9 @@ class GrokZephyrApp {
 
     // Pass 2: Scene rendering (different for ground view)
     if (this.camera.getViewMode() === 'ground') {
-      const groundRenderer = this.groundViewEnabled ? this.earthAtmosphereRenderer : null;
-      this.pipeline.encodeGroundScenePass(
-        encoder,
-        groundRenderer ?? undefined,
-        this.earthVertexBuffer ?? undefined,
-        this.earthIndexBuffer ?? undefined,
-        this.earthIndexCount
-      );
+      const hz = this.groundObserver.getHorizonSettings();
+      this.pipeline.setGroundViewParams(hz.oceanBias, hz.urbanGlow, hz.overlayFade, hz.hazeBoost);
+      this.pipeline.encodeGroundScenePass(encoder);
     } else {
       this.pipeline.encodeScenePass(
         encoder,

--- a/src/render/RenderPipeline.ts
+++ b/src/render/RenderPipeline.ts
@@ -13,7 +13,6 @@
 
 import type WebGPUContext from '@/core/WebGPUContext.js';
 import type { SatelliteBufferSet } from '@/core/SatelliteGPUBuffer.js';
-import type { EarthAtmosphereRenderer } from '@/earth.js';
 import type { BloomConfig } from '@/types/animation.js';
 import { SmileV2Pipeline } from './SmileV2Pipeline.js';
 import { SHADERS } from '@/shaders/index.js';
@@ -198,6 +197,12 @@ export class RenderPipeline {
   private dofUniformBuffer: GPUBuffer | null = null;
   /** Uniform buffer for atmosphere scattering controls. */
   private atmosphereSettingsBuffer: GPUBuffer | null = null;
+  /** Uniform buffer for ground-view horizon preset params (GroundParams). */
+  private groundParamsBuffer: GPUBuffer | null = null;
+  /** Current ground horizon params: oceanBias, urbanGlow, overlayFade, hazeBoost. */
+  private groundViewParams: [number, number, number, number] = [0, 0.4, 0.6, 1.0];
+  /** Whether the ground horizon quad is drawn in the ground scene pass. */
+  private groundTerrainEnabled = true;
   /** Motion blur uniforms (previous VP + inverse VP + strengths). */
   private motionBlurUniformBuffer: GPUBuffer | null = null;
   /** Auto exposure histogram (64 bins). */
@@ -282,13 +287,6 @@ export class RenderPipeline {
       ],
     });
 
-    // Uniform-only render layout
-    const uniformLayout = device.createBindGroupLayout({
-      entries: [
-        { binding: 0, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT, buffer: { type: 'uniform' } },
-      ],
-    });
-
     // Shared scene atmosphere layout (uniform + LUT + sampler + settings)
     const sceneAtmosphereLayout = device.createBindGroupLayout({
       entries: [
@@ -296,6 +294,17 @@ export class RenderPipeline {
         { binding: 1, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: 'float' } },
         { binding: 2, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' } },
         { binding: 3, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'uniform' } },
+      ],
+    });
+
+    // Ground horizon layout: scene atmosphere bindings + per-preset GroundParams
+    const groundTerrainLayout = device.createBindGroupLayout({
+      entries: [
+        { binding: 0, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT, buffer: { type: 'uniform' } },
+        { binding: 1, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: 'float' } },
+        { binding: 2, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' } },
+        { binding: 3, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'uniform' } },
+        { binding: 4, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'uniform' } },
       ],
     });
 
@@ -580,7 +589,7 @@ export class RenderPipeline {
       }),
 
       groundTerrain: device.createRenderPipeline({
-        layout: device.createPipelineLayout({ bindGroupLayouts: [uniformLayout] }),
+        layout: device.createPipelineLayout({ bindGroupLayouts: [groundTerrainLayout] }),
         vertex: {
           module: this.context.createShaderModule(SHADERS.render.ground, 'ground-terrain'),
           entryPoint: 'vs',
@@ -848,7 +857,7 @@ export class RenderPipeline {
     if (!this.bloomThresholdUniformBuffer || !this.bloomCompositeUniformBuffer || !this.tonemapUniformBuffer) return;
     if (!this.motionBlurUniformBuffer) return;
     if (!this.atmosphereLUTView || !this.atmosphereSettingsBuffer) return;
-    if (!this.autoExposureStateBuffer) return;
+    if (!this.autoExposureStateBuffer || !this.groundParamsBuffer) return;
 
     const device = this.context.getDevice();
     const posBuffer = this.buffers.positions instanceof GPUBuffer
@@ -931,7 +940,13 @@ export class RenderPipeline {
 
     groundTerrain: device.createBindGroup({
       layout: this.pipelines.groundTerrain.getBindGroupLayout(0),
-      entries: [{ binding: 0, resource: { buffer: this.buffers.uniforms } }],
+      entries: [
+        { binding: 0, resource: { buffer: this.buffers.uniforms } },
+        { binding: 1, resource: this.atmosphereLUTView },
+        { binding: 2, resource: this.linearSampler },
+        { binding: 3, resource: { buffer: this.atmosphereSettingsBuffer } },
+        { binding: 4, resource: { buffer: this.groundParamsBuffer } },
+      ],
     }),
 
     bloomThreshold: device.createBindGroup({
@@ -1118,15 +1133,32 @@ export class RenderPipeline {
   }
 
   /**
-   * Execute ground view scene render pass (mountains, lake, satellites, beams)
+   * Set the ground horizon preset params (GroundParams uniform).
+   * Cheap no-op when values are unchanged.
    */
-  encodeGroundScenePass(
-    encoder: GPUCommandEncoder,
-    earthAtmosphereRenderer?: EarthAtmosphereRenderer,
-    earthVertexBuffer?: GPUBuffer,
-    earthIndexBuffer?: GPUBuffer,
-    earthIndexCount?: number
-  ): void {
+  setGroundViewParams(oceanBias: number, urbanGlow: number, overlayFade: number, hazeBoost: number): void {
+    const [o, u, f, h] = this.groundViewParams;
+    if (o === oceanBias && u === urbanGlow && f === overlayFade && h === hazeBoost) return;
+    this.groundViewParams = [oceanBias, urbanGlow, overlayFade, hazeBoost];
+    this.writeGroundViewParams();
+  }
+
+  /** Toggle the ground horizon quad (stars/satellites/beams still draw). */
+  setGroundTerrainEnabled(enabled: boolean): void {
+    this.groundTerrainEnabled = enabled;
+  }
+
+  private writeGroundViewParams(): void {
+    if (!this.groundParamsBuffer) return;
+    const device = this.context.getDevice();
+    device.queue.writeBuffer(this.groundParamsBuffer, 0, new Float32Array(this.groundViewParams));
+  }
+
+  /**
+   * Execute ground view scene render pass: starfield → ray-traced horizon
+   * (fullscreen quad, no Earth sphere draw) → satellites → beams.
+   */
+  encodeGroundScenePass(encoder: GPUCommandEncoder): void {
     if (!this.pipelines || !this.bindGroups || !this.renderTargets) return;
 
     const pass = encoder.beginRenderPass({
@@ -1146,15 +1178,12 @@ export class RenderPipeline {
 
     pass.setViewport(0, 0, this.width, this.height, 0, 1);
 
-    if (earthAtmosphereRenderer && earthAtmosphereRenderer.getEnabled() && earthVertexBuffer && earthIndexBuffer && earthIndexCount) {
-      pass.setPipeline(this.pipelines.earth);
-      pass.setBindGroup(0, this.bindGroups.earth);
-      pass.setVertexBuffer(0, earthVertexBuffer);
-      pass.setIndexBuffer(earthIndexBuffer, 'uint32');
-      pass.drawIndexed(earthIndexCount);
+    // Starfield behind everything; the horizon quad's sky alpha lets it show
+    pass.setPipeline(this.pipelines.stars);
+    pass.setBindGroup(0, this.bindGroups.stars);
+    pass.draw(3);
 
-      earthAtmosphereRenderer.encode(pass, earthVertexBuffer, earthIndexBuffer, earthIndexCount);
-    } else {
+    if (this.groundTerrainEnabled) {
       pass.setPipeline(this.pipelines.groundTerrain);
       pass.setBindGroup(0, this.bindGroups.groundTerrain);
       pass.draw(6);
@@ -1729,6 +1758,8 @@ export class RenderPipeline {
     this.dofUniformBuffer = null;
     this.atmosphereSettingsBuffer?.destroy();
     this.atmosphereSettingsBuffer = null;
+    this.groundParamsBuffer?.destroy();
+    this.groundParamsBuffer = null;
     this.motionBlurUniformBuffer?.destroy();
     this.motionBlurUniformBuffer = null;
     this.autoExposureHistogramBuffer?.destroy();
@@ -1929,6 +1960,15 @@ export class RenderPipeline {
       });
     }
     this.writeAtmosphereScatteringUniform();
+
+    if (!this.groundParamsBuffer) {
+      this.groundParamsBuffer = device.createBuffer({
+        size: 16,
+        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+        label: 'Ground View Params',
+      });
+      this.writeGroundViewParams();
+    }
 
     if (!this.motionBlurUniformBuffer) {
       this.motionBlurUniformBuffer = device.createBuffer({

--- a/src/shaders/render/earth.ts
+++ b/src/shaders/render/earth.ts
@@ -4,8 +4,9 @@
  */
 
 import { UNIFORM_STRUCT } from '../uniforms.js';
+import { TERRAIN_COMMON } from './terrainCommon.js';
 
-export const EARTH_SHADER = UNIFORM_STRUCT + /* wgsl */ `
+export const EARTH_SHADER = UNIFORM_STRUCT + TERRAIN_COMMON + /* wgsl */ `
 struct VIn  { @location(0) pos:vec3f, @location(1) nrm:vec3f }
 struct VOut { @builtin(position) cp:vec4f, @location(0) wp:vec3f, @location(1) n:vec3f }
 
@@ -20,14 +21,6 @@ struct AtmosphereSettings {
 @group(0) @binding(2) var atmosphereSampler: sampler;
 @group(0) @binding(3) var<uniform> atmosphereSettings: AtmosphereSettings;
 
-const PI: f32 = 3.14159265;
-const EARTH_SIDEREAL_PERIOD: f32 = 86164.0;  // seconds — one sidereal day
-const TWILIGHT_COS_HALF:     f32 = 0.12;     // ≈ 6.9° angular half-width of twilight band
-const NIGHT_START:           f32 = 0.08;     // sun-dot threshold where night begins
-const NIGHT_END:             f32 = -0.06;    // sun-dot threshold where night is full
-const RAYLEIGH_COEFF = vec3f(5.8e-3, 13.5e-3, 33.1e-3);
-const MIE_COEFF = vec3f(2.1e-2);
-
 @vertex fn vs(v:VIn) -> VOut {
   var o:VOut;
   o.cp = uni.view_proj * vec4f(v.pos,1);
@@ -36,119 +29,11 @@ const MIE_COEFF = vec3f(2.1e-2);
   return o;
 }
 
-// Simplex-like noise (hash-based approximation)
-fn hash3d(p:vec3f)->f32 {
-  return fract(sin(dot(p,vec3f(127.1,311.7,74.7)))*43758.5453);
-}
-
-fn noise3d(p:vec3f)->f32 {
-  let i = floor(p);
-  let f = fract(p);
-  let u = f * f * (3.0 - 2.0 * f);
-  return mix(
-    mix(mix(hash3d(i + vec3f(0,0,0)), hash3d(i + vec3f(1,0,0)), u.x),
-        mix(hash3d(i + vec3f(0,1,0)), hash3d(i + vec3f(1,1,0)), u.x), u.y),
-    mix(mix(hash3d(i + vec3f(0,0,1)), hash3d(i + vec3f(1,0,1)), u.x),
-        mix(hash3d(i + vec3f(0,1,1)), hash3d(i + vec3f(1,1,1)), u.x), u.y),
-    u.z
-  );
-}
-
-fn fbmTerrain(pos:vec3f, octaves:i32)->f32 {
-  var value = 0.0;
-  var amplitude = 0.5;
-  var frequency = 1.0;
-  var maxValue = 0.0;
-  for (var i = 0; i < octaves; i++) {
-    value += amplitude * noise3d(pos * frequency);
-    maxValue += amplitude;
-    amplitude *= 0.5;
-    frequency *= 2.0;
-  }
-  return value / maxValue;
-}
-
-fn biomeColor(height:f32, latitude:f32, slope:f32)->vec3f {
-  const SEA_LEVEL = 0.45;
-  const COASTAL   = 0.48;
-  const PLAINS    = 0.55;
-  const HILLS     = 0.70;
-  const MOUNTAIN  = 0.85;
-
-  let temp = 1.0 - abs(latitude) / (PI / 2.0);
-
-  let ocean  = vec3f(0.02, 0.08, 0.18);
-  let beach  = vec3f(0.76, 0.70, 0.50);
-  let grass  = mix(vec3f(0.25, 0.45, 0.15), vec3f(0.15, 0.35, 0.10), temp);
-  let forest = mix(vec3f(0.12, 0.28, 0.08), vec3f(0.08, 0.20, 0.05), temp);
-  let rock   = vec3f(0.35, 0.32, 0.28);
-  let snow   = vec3f(0.90, 0.92, 0.95);
-
-  var color: vec3f;
-  if (height < SEA_LEVEL) {
-    color = ocean;
-  } else if (height < COASTAL) {
-    color = mix(ocean, beach, (height - SEA_LEVEL) / (COASTAL - SEA_LEVEL));
-  } else if (height < PLAINS) {
-    color = mix(beach, grass, (height - COASTAL) / (PLAINS - COASTAL));
-  } else if (height < HILLS) {
-    color = mix(grass, forest, (height - PLAINS) / (HILLS - PLAINS));
-  } else if (height < MOUNTAIN) {
-    color = mix(forest, rock, (height - HILLS) / (MOUNTAIN - HILLS));
-  } else {
-    color = mix(rock, snow, (height - MOUNTAIN) / (1.0 - MOUNTAIN));
-  }
-
-  // Steeper terrain shows more rock
-  let slopeFactor = smoothstep(0.3, 0.7, slope);
-  color = mix(color, rock, slopeFactor * 0.7);
-
-  // Texture variation via noise
-  let detail = noise3d(normalize(vec3f(height, latitude, slope)) * 500.0) * 0.1 + 0.9;
-  return color * detail;
-}
-
 // Two-octave animated cloud noise (cheap: 2 octaves only)
 fn cloudNoise(pos: vec3f, time: f32) -> f32 {
   let p0 = pos * 2.8 + vec3f(time * 0.006, time * 0.004, 0.0);
   let p1 = pos * 5.6 + vec3f(time * 0.009, 0.0, time * 0.003);
   return noise3d(p0) * 0.6 + noise3d(p1) * 0.4;
-}
-
-// ── 2-D noise helpers for city-light clustering ──────────────────────────────
-// Separate from the 3-D terrain hash to avoid any frequency aliasing.
-// Constants 127.1, 311.7, 43758.5453 are standard hash primes for smooth PRNG.
-fn hash2c(p: vec2f) -> f32 {
-  return fract(sin(dot(p, vec2f(127.1, 311.7))) * 43758.5453);
-}
-
-fn noise2c(p: vec2f) -> f32 {
-  let i = floor(p);
-  let f = fract(p);
-  let u = f * f * (3.0 - 2.0 * f);
-  return mix(
-    mix(hash2c(i + vec2f(0,0)), hash2c(i + vec2f(1,0)), u.x),
-    mix(hash2c(i + vec2f(0,1)), hash2c(i + vec2f(1,1)), u.x),
-    u.y
-  );
-}
-
-// 4-octave 2-D FBM for organic, non-repeating city-light patterns
-fn fbmCity(p: vec2f) -> f32 {
-  var v = 0.0;
-  var a = 0.5;
-  var x = p;
-  for (var i = 0; i < 4; i++) {
-    v += a * noise2c(x);
-    x *= 2.0;
-    a *= 0.5;
-  }
-  return v;
-}
-
-
-fn schlickFresnel(cosTheta:f32, F0:f32)->f32 {
-  return F0 + (1.0 - F0) * pow(clamp(1.0 - cosTheta, 0.0, 1.0), 5.0);
 }
 
 // Gerstner wave contribution for ocean normals
@@ -283,25 +168,9 @@ fn oceanColor(worldPos:vec3f, normal:vec3f, viewDir:vec3f, sunDir:vec3f, time:f3
   let twilightBand = smoothstep(-TWILIGHT_COS_HALF, 0.0, sunDot) * (1.0 - smoothstep(0.0, TWILIGHT_COS_HALF, sunDot));
   surf += vec3f(1.0, 0.38, 0.08) * twilightBand * 0.22;
 
-  // City lights: FBM-based for plausible coastal/river density patterns.
-  // Strictly night-side — fade in only as sunDot goes negative.
-  let night = smoothstep(NIGHT_START, NIGHT_END, sunDot);
-  // Coarse FBM captures large population clusters; fine FBM adds sub-city variation
-  let cityCoarse = fbmCity(vec2f(lat * 6.0,  lon * 8.0));
-  let cityFine   = fbmCity(vec2f(lat * 25.0 + 1.7, lon * 19.0 + 2.3));
-  // Coastal elevation bias: cities cluster near coasts and river-delta plains
-  let coastalBias = smoothstep(0.44, 0.52, height) * (1.0 - smoothstep(0.52, 0.76, height));
-  // Latitude weighting: favour temperate zones ~20°-60° (less near equator/poles)
-  let absLat = abs(lat) / (PI / 2.0);
-  let latWeight = smoothstep(0.07, 0.22, absLat) * (1.0 - smoothstep(0.60, 0.80, absLat));
-  // Final density: land × coastal × latitude × FBM cluster threshold
-  let cityDensity = f32(isLand) * coastalBias * latWeight * smoothstep(0.38, 0.58, cityCoarse);
-  let cityMask = cityDensity * (0.55 + 0.45 * cityFine);
-  // Warm sodium-vapour lights + cool LED cores in dense centres + faint blue atmospheric haze
-  let warmLight = vec3f(1.0, 0.78, 0.28) * cityMask;
-  let coolLight = vec3f(0.9, 0.95, 1.0) * pow(cityMask, 2.5) * 0.45;
-  let cityHaze  = vec3f(0.15, 0.20, 0.40) * cityMask * 0.35;
-  let cityWarm = (warmLight + coolLight + cityHaze) * night * 0.18;
+  // City lights: FBM-based for plausible coastal/river density patterns
+  // (shared with the Ground View horizon shader via cityLightEmission).
+  let cityWarm = cityLightEmission(lat, lon, height, isLand, sunDot);
 
   let viewDir = normalize(uni.camera_pos.xyz - in.wp);
   let horizonFactor = clamp(1.0 - abs(dot(N, viewDir)), 0.0, 1.0);

--- a/src/shaders/render/ground.ts
+++ b/src/shaders/render/ground.ts
@@ -1,10 +1,50 @@
 /**
- * Ground Terrain Shader
+ * Ground View Horizon Shader
+ *
+ * Screen-space horizon reconstruction for Ground View. Instead of drawing the
+ * full Earth sphere mesh, a single fullscreen quad ray-traces the Earth from
+ * the observer position:
+ *
+ *  - The per-pixel view ray is rebuilt from the shared view_proj matrix
+ *    (camera basis + FOV extracted from the matrix rows).
+ *  - Rays that hit the Earth sample the same procedural FBM terrain, biome
+ *    palette, and city-light clusters as the orbital Earth shader
+ *    (terrainCommon.ts), so the horizon matches the photoreal globe.
+ *  - Rays that miss get a physically-plausible sky: twilight scattering,
+ *    a low-altitude Mie haze band hugging the horizon (atmosphere LUT when
+ *    enabled), and a night-side city-light glow band along the horizon.
+ *  - Preset bias uniforms (GroundParams) shift the treatment per observer
+ *    preset: ocean bias for the beach, urban glow for the rooftop, and an
+ *    overlay fade that dims the pass where the CSS frame covers the frame.
+ *
+ * Sky pixels output low alpha so the starfield drawn beneath shows through.
  */
 
 import { UNIFORM_STRUCT } from '../uniforms.js';
+import { TERRAIN_COMMON } from './terrainCommon.js';
 
-export const GROUND_TERRAIN = UNIFORM_STRUCT + /* wgsl */ `
+export const GROUND_TERRAIN = UNIFORM_STRUCT + TERRAIN_COMMON + /* wgsl */ `
+struct AtmosphereSettings {
+  scatteringEnabled: u32,
+  _pad0: u32,
+  hazeStrength: f32,
+  _pad1: f32,
+}
+
+struct GroundParams {
+  ocean_bias   : f32,  // >0 sinks terrain toward ocean (beach preset)
+  urban_glow   : f32,  // night city-light glow strength near the horizon
+  overlay_fade : f32,  // fades the pass where the CSS frame overlay covers it
+  haze_boost   : f32,  // low-altitude Mie haze multiplier (per-preset)
+}
+
+@group(0) @binding(1) var atmosphereLUT: texture_2d<f32>;
+@group(0) @binding(2) var atmosphereSampler: sampler;
+@group(0) @binding(3) var<uniform> atmosphereSettings: AtmosphereSettings;
+@group(0) @binding(4) var<uniform> ground: GroundParams;
+
+const EARTH_R: f32 = 6371.0;
+
 struct VOut {
   @builtin(position) cp : vec4f,
   @location(0) uv       : vec2f,
@@ -16,20 +56,197 @@ fn vs(@builtin(vertex_index) vi : u32) -> VOut {
     vec2f(-1.0, -1.0), vec2f(1.0, -1.0), vec2f(-1.0, 1.0),
     vec2f(-1.0,  1.0), vec2f(1.0, -1.0), vec2f( 1.0, 1.0)
   );
-  
+
   var out: VOut;
   out.cp = vec4f(quad[vi], 0.0, 1.0);
   out.uv = quad[vi] * 0.5 + 0.5;
   return out;
 }
 
+// Rebuild the world-space view ray for a pixel from the view_proj matrix.
+//
+// view_proj = P * V with P a standard perspective matrix (last row [0,0,-1,0])
+// and V an orthonormal lookAt. Therefore, taking rows of the upper 3x4:
+//   row_w(xyz) = -viewRow2       = camera forward (unit)
+//   row_x(xyz) = P00 * viewRow0  → normalize = camera right, 1/|row_x| = tan(fovX/2)
+//   row_y(xyz) = P11 * viewRow1  → normalize = camera up,    1/|row_y| = tan(fovY/2)
+fn viewRay(uv: vec2f) -> vec3f {
+  let ndc = uv * 2.0 - 1.0;
+  let m = uni.view_proj;
+  let rowX = vec3f(m[0].x, m[1].x, m[2].x);
+  let rowY = vec3f(m[0].y, m[1].y, m[2].y);
+  let rowW = vec3f(m[0].w, m[1].w, m[2].w);
+  let tanX = 1.0 / length(rowX);
+  let tanY = 1.0 / length(rowY);
+  return normalize(normalize(rowW)
+    + ndc.x * tanX * normalize(rowX)
+    + ndc.y * tanY * normalize(rowY));
+}
+
 @fragment
 fn fs(in: VOut) -> @location(0) vec4f {
-  // Simple horizon gradient
-  let horizon = smoothstep(0.4, 0.5, in.uv.y);
-  let groundColor = vec3f(0.05, 0.08, 0.12);
-  let skyColor = vec3f(0.02, 0.03, 0.08);
-  let color = mix(groundColor, skyColor, horizon);
-  return vec4f(color, 1.0);
+  let rd = viewRay(in.uv);
+  let ro = uni.camera_pos.xyz;
+  let up = normalize(ro);
+  let sunDir = normalize(uni.sun_position.xyz);
+  let sunElev = dot(up, sunDir);          // sun elevation at the observer
+  let cosVZ = dot(rd, up);                // view-zenith cosine
+  let day = smoothstep(-0.08, 0.25, sunElev);
+  let night = smoothstep(0.02, -0.10, sunElev);
+  let twilight = smoothstep(-0.28, -0.05, sunElev) * (1.0 - smoothstep(-0.02, 0.14, sunElev));
+
+  // Ray–sphere intersection against the Earth
+  let b = dot(ro, rd);
+  let c = dot(ro, ro) - EARTH_R * EARTH_R;
+  let disc = b * b - c;
+  let t = -b - sqrt(max(disc, 0.0));
+  let hitsGround = disc > 0.0 && t > 0.0;
+
+  var color: vec3f;
+  var alpha: f32;
+
+  if (hitsGround) {
+    // ── Terrain: same body-frame sampling as the orbital Earth shader ──────
+    let p = ro + rd * t;
+    let N = p / EARTH_R;
+
+    let earthRotAngle = 2.0 * PI * uni.sim_time / EARTH_SIDEREAL_PERIOD;
+    let cosR = cos(earthRotAngle);
+    let sinR = sin(earthRotAngle);
+    let wp_rot = vec3f(
+      N.x * cosR - N.y * sinR,
+      N.x * sinR + N.y * cosR,
+      N.z
+    );
+
+    let lat = asin(clamp(wp_rot.z, -1.0, 1.0));
+    let lon = atan2(wp_rot.y, wp_rot.x);
+
+    // Preset ocean bias sinks the terrain so beaches face open water
+    let height = clamp(fbmTerrain(wp_rot * 3.0, 4) - ground.ocean_bias, 0.0, 1.0);
+    let sunDot = dot(N, sunDir);
+    let isLand = height > 0.45;
+
+    var surf: vec3f;
+    if (isLand) {
+      // Cheap slope estimate from one offset FBM sample (forward difference)
+      let eps = 0.01;
+      let hX = fbmTerrain(normalize(wp_rot + vec3f(eps, 0.0, 0.0)) * 3.0, 4);
+      let hY = fbmTerrain(normalize(wp_rot + vec3f(0.0, eps, 0.0)) * 3.0, 4);
+      let gradient = vec2f(hX - height - ground.ocean_bias, hY - height - ground.ocean_bias) / eps;
+      let slope = clamp(length(gradient) * 0.7, 0.0, 1.0);
+
+      surf = biomeColor(height, lat, slope);
+
+      // Polar/altitude snow, matching the orbital shader
+      let pole = smoothstep(1.1, 1.4, abs(lat));
+      let snowLine = smoothstep(0.82, 0.88, height) * (1.0 - abs(lat) / (PI / 2.0));
+      surf = mix(surf, vec3f(0.90, 0.92, 0.95), max(pole, snowLine));
+
+      // Terrain-perturbed lighting
+      let terrNormBody = normalize(vec3f(-gradient.x, -gradient.y, 1.0));
+      let terrNormECI = vec3f(
+        terrNormBody.x * cosR + terrNormBody.y * sinR,
+       -terrNormBody.x * sinR + terrNormBody.y * cosR,
+        terrNormBody.z
+      );
+      let modN = normalize(N + terrNormECI * 0.3);
+      let NdotL = max(dot(modN, sunDir), 0.0);
+      surf = surf * (NdotL * 0.92 + 0.05);
+    } else {
+      // Ocean: Fresnel + sun glint + animated shimmer (beach preset)
+      let w1 = noise3d(wp_rot * 700.0 + vec3f(uni.time * 0.5)) - 0.5;
+      let w2 = noise3d(wp_rot * 1300.0 - vec3f(uni.time * 0.7)) - 0.5;
+      let Nw = normalize(N + vec3f(w1, w2, w1 * w2) * 0.10);
+      let VdotN = max(dot(-rd, Nw), 0.0);
+      let fresnel = schlickFresnel(VdotN, 0.02);
+      let NdotL = max(dot(Nw, sunDir), 0.0);
+
+      let deepColor = vec3f(0.02, 0.08, 0.18);
+      let shallowColor = vec3f(0.05, 0.25, 0.40);
+      surf = mix(deepColor, shallowColor, 0.3) * (NdotL * 0.85 + 0.05);
+
+      // Sun glint
+      let H = normalize(-rd + sunDir);
+      surf += vec3f(1.0, 0.85, 0.6) * pow(max(dot(Nw, H), 0.0), 180.0) * fresnel * 3.0;
+
+      // Night sky/starlight sparkle on the swell — the beach shimmer
+      let sparkle = smoothstep(0.78, 0.98,
+        noise3d(wp_rot * 4200.0 + vec3f(uni.time * 1.7, 0.0, -uni.time * 1.3)));
+      surf += vec3f(0.35, 0.45, 0.60) * sparkle * fresnel * night * 0.6;
+
+      // Sky reflection
+      surf += mix(vec3f(0.02, 0.03, 0.07), vec3f(0.40, 0.55, 0.80), day) * fresnel * 0.5;
+    }
+
+    // Twilight band along the terminator
+    let twilightBand = smoothstep(-TWILIGHT_COS_HALF, 0.0, sunDot)
+      * (1.0 - smoothstep(0.0, TWILIGHT_COS_HALF, sunDot));
+    surf += vec3f(1.0, 0.38, 0.08) * twilightBand * 0.22;
+
+    // Night-side city lights, boosted by the preset urban glow
+    surf += cityLightEmission(lat, lon, height, isLand, sunDot) * (1.0 + ground.urban_glow * 1.6);
+
+    // ── Aerial perspective: distance haze toward the limb ──────────────────
+    let hazeAmt = clamp((1.0 - exp(-t * 0.0018)) * ground.haze_boost, 0.0, 1.0);
+    var hazeColor = mix(vec3f(0.020, 0.032, 0.065), vec3f(0.42, 0.56, 0.80), day);
+    hazeColor += vec3f(0.85, 0.32, 0.10) * twilight * 0.5;
+
+    if (atmosphereSettings.scatteringEnabled != 0u) {
+      let lutUV = vec2f(clamp(cosVZ, -1.0, 1.0) * 0.5 + 0.5, clamp(sunElev, -1.0, 1.0) * 0.5 + 0.5);
+      // textureSampleLevel: this branch is non-uniform (per-pixel ray hit)
+      let od = textureSampleLevel(atmosphereLUT, atmosphereSampler, lutUV, 0.0).rg;
+      let transmittance = exp(-(RAYLEIGH_COEFF * od.r + MIE_COEFF * od.g));
+      surf *= mix(vec3f(1.0), transmittance, hazeAmt * atmosphereSettings.hazeStrength);
+    }
+
+    color = mix(surf, hazeColor, hazeAmt * 0.55);
+    alpha = 1.0;
+  } else {
+    // ── Sky: haze band, twilight scatter, and night city glow at the horizon ──
+    // True horizon dip for the observer altitude
+    let cosH = -sqrt(max(1.0 - (EARTH_R * EARTH_R) / dot(ro, ro), 0.0));
+    let band = exp(-max(cosVZ - cosH, 0.0) * 14.0);
+
+    let skyDay = vec3f(0.16, 0.34, 0.68);
+    let skyNight = vec3f(0.008, 0.014, 0.038);
+    var sky = mix(skyNight, skyDay, day) * (0.22 + 0.78 * band);
+
+    // Twilight glow, strongest toward the sun's azimuth
+    let sunH = sunDir - up * sunElev;
+    let rdH = rd - up * cosVZ;
+    let toward = max(dot(normalize(sunH + vec3f(1e-5)), normalize(rdH + vec3f(1e-5))), 0.0);
+    sky += vec3f(1.0, 0.42, 0.14) * twilight * band * (0.25 + 0.75 * pow(toward, 3.0)) * 0.9;
+
+    // Night-side city-light band: clumpy warm glow hugging the horizon,
+    // matching the Earth shader's night lights in tone
+    let north = normalize(vec3f(0.0, 0.0, 1.0) - up * up.z + vec3f(1e-5));
+    let east = cross(north, up);
+    let azim = atan2(dot(rdH, east), dot(rdH, north));
+    let clump = fbmCity(vec2f(azim * 3.0 + uni.sim_time * 0.00007, 1.7));
+    let cityBand = smoothstep(0.35, 0.75, clump) * band * band * night;
+    sky += vec3f(1.0, 0.62, 0.26) * cityBand * (0.12 + ground.urban_glow * 0.55);
+    sky += vec3f(0.30, 0.24, 0.34) * band * band * night * ground.urban_glow * 0.20;
+
+    // Low-altitude Mie haze via the atmosphere LUT
+    if (atmosphereSettings.scatteringEnabled != 0u) {
+      let lutUV = vec2f(clamp(cosVZ, -1.0, 1.0) * 0.5 + 0.5, clamp(sunElev, -1.0, 1.0) * 0.5 + 0.5);
+      let od = textureSampleLevel(atmosphereLUT, atmosphereSampler, lutUV, 0.0).rg;
+      let mieGlow = 1.0 - exp(-od.g * MIE_COEFF);
+      sky += mieGlow * band * atmosphereSettings.hazeStrength * ground.haze_boost
+        * mix(vec3f(0.25, 0.30, 0.45), vec3f(1.0, 0.85, 0.65), day);
+    }
+
+    color = sky;
+    // Opaque haze at the horizon; transparent higher up so stars show through
+    alpha = clamp(band * (0.55 + 0.35 * ground.haze_boost) + day * 0.55 + twilight * 0.25, 0.0, 1.0);
+  }
+
+  // Fade the pass where the CSS frame overlay (house sill, car dashboard)
+  // covers the lower part of the frame
+  let fade = ground.overlay_fade * (1.0 - smoothstep(0.08, 0.42, in.uv.y));
+  alpha *= 1.0 - fade;
+
+  return vec4f(color, alpha);
 }
 `;

--- a/src/shaders/render/terrainCommon.ts
+++ b/src/shaders/render/terrainCommon.ts
@@ -1,0 +1,151 @@
+/**
+ * Shared WGSL Terrain Helpers
+ *
+ * Procedural terrain, biome, and city-light functions used by both the Earth
+ * sphere shader (orbit views) and the Ground View horizon shader, so both
+ * sample identical terrain heights, biome colors, and night-light clusters.
+ *
+ * Concatenate after UNIFORM_STRUCT and before shader-specific code.
+ */
+
+export const TERRAIN_COMMON = /* wgsl */ `
+const PI: f32 = 3.14159265;
+const EARTH_SIDEREAL_PERIOD: f32 = 86164.0;  // seconds — one sidereal day
+const TWILIGHT_COS_HALF:     f32 = 0.12;     // ≈ 6.9° angular half-width of twilight band
+const NIGHT_START:           f32 = 0.08;     // sun-dot threshold where night begins
+const NIGHT_END:             f32 = -0.06;    // sun-dot threshold where night is full
+const RAYLEIGH_COEFF = vec3f(5.8e-3, 13.5e-3, 33.1e-3);
+const MIE_COEFF = vec3f(2.1e-2);
+
+// Simplex-like noise (hash-based approximation)
+fn hash3d(p:vec3f)->f32 {
+  return fract(sin(dot(p,vec3f(127.1,311.7,74.7)))*43758.5453);
+}
+
+fn noise3d(p:vec3f)->f32 {
+  let i = floor(p);
+  let f = fract(p);
+  let u = f * f * (3.0 - 2.0 * f);
+  return mix(
+    mix(mix(hash3d(i + vec3f(0,0,0)), hash3d(i + vec3f(1,0,0)), u.x),
+        mix(hash3d(i + vec3f(0,1,0)), hash3d(i + vec3f(1,1,0)), u.x), u.y),
+    mix(mix(hash3d(i + vec3f(0,0,1)), hash3d(i + vec3f(1,0,1)), u.x),
+        mix(hash3d(i + vec3f(0,1,1)), hash3d(i + vec3f(1,1,1)), u.x), u.y),
+    u.z
+  );
+}
+
+fn fbmTerrain(pos:vec3f, octaves:i32)->f32 {
+  var value = 0.0;
+  var amplitude = 0.5;
+  var frequency = 1.0;
+  var maxValue = 0.0;
+  for (var i = 0; i < octaves; i++) {
+    value += amplitude * noise3d(pos * frequency);
+    maxValue += amplitude;
+    amplitude *= 0.5;
+    frequency *= 2.0;
+  }
+  return value / maxValue;
+}
+
+fn biomeColor(height:f32, latitude:f32, slope:f32)->vec3f {
+  const SEA_LEVEL = 0.45;
+  const COASTAL   = 0.48;
+  const PLAINS    = 0.55;
+  const HILLS     = 0.70;
+  const MOUNTAIN  = 0.85;
+
+  let temp = 1.0 - abs(latitude) / (PI / 2.0);
+
+  let ocean  = vec3f(0.02, 0.08, 0.18);
+  let beach  = vec3f(0.76, 0.70, 0.50);
+  let grass  = mix(vec3f(0.25, 0.45, 0.15), vec3f(0.15, 0.35, 0.10), temp);
+  let forest = mix(vec3f(0.12, 0.28, 0.08), vec3f(0.08, 0.20, 0.05), temp);
+  let rock   = vec3f(0.35, 0.32, 0.28);
+  let snow   = vec3f(0.90, 0.92, 0.95);
+
+  var color: vec3f;
+  if (height < SEA_LEVEL) {
+    color = ocean;
+  } else if (height < COASTAL) {
+    color = mix(ocean, beach, (height - SEA_LEVEL) / (COASTAL - SEA_LEVEL));
+  } else if (height < PLAINS) {
+    color = mix(beach, grass, (height - COASTAL) / (PLAINS - COASTAL));
+  } else if (height < HILLS) {
+    color = mix(grass, forest, (height - PLAINS) / (HILLS - PLAINS));
+  } else if (height < MOUNTAIN) {
+    color = mix(forest, rock, (height - HILLS) / (MOUNTAIN - HILLS));
+  } else {
+    color = mix(rock, snow, (height - MOUNTAIN) / (1.0 - MOUNTAIN));
+  }
+
+  // Steeper terrain shows more rock
+  let slopeFactor = smoothstep(0.3, 0.7, slope);
+  color = mix(color, rock, slopeFactor * 0.7);
+
+  // Texture variation via noise
+  let detail = noise3d(normalize(vec3f(height, latitude, slope)) * 500.0) * 0.1 + 0.9;
+  return color * detail;
+}
+
+// ── 2-D noise helpers for city-light clustering ──────────────────────────────
+// Separate from the 3-D terrain hash to avoid any frequency aliasing.
+// Constants 127.1, 311.7, 43758.5453 are standard hash primes for smooth PRNG.
+fn hash2c(p: vec2f) -> f32 {
+  return fract(sin(dot(p, vec2f(127.1, 311.7))) * 43758.5453);
+}
+
+fn noise2c(p: vec2f) -> f32 {
+  let i = floor(p);
+  let f = fract(p);
+  let u = f * f * (3.0 - 2.0 * f);
+  return mix(
+    mix(hash2c(i + vec2f(0,0)), hash2c(i + vec2f(1,0)), u.x),
+    mix(hash2c(i + vec2f(0,1)), hash2c(i + vec2f(1,1)), u.x),
+    u.y
+  );
+}
+
+// 4-octave 2-D FBM for organic, non-repeating city-light patterns
+fn fbmCity(p: vec2f) -> f32 {
+  var v = 0.0;
+  var a = 0.5;
+  var x = p;
+  for (var i = 0; i < 4; i++) {
+    v += a * noise2c(x);
+    x *= 2.0;
+    a *= 0.5;
+  }
+  return v;
+}
+
+fn schlickFresnel(cosTheta:f32, F0:f32)->f32 {
+  return F0 + (1.0 - F0) * pow(clamp(1.0 - cosTheta, 0.0, 1.0), 5.0);
+}
+
+// City-light emission for a surface point given its body-frame lat/lon,
+// terrain height, land mask, and sun-dot (night factor). Shared between the
+// Earth sphere shader and the Ground View horizon shader so night lights
+// match across views.
+fn cityLightEmission(lat: f32, lon: f32, height: f32, isLand: bool, sunDot: f32) -> vec3f {
+  // Strictly night-side — fade in only as sunDot goes negative.
+  let night = smoothstep(NIGHT_START, NIGHT_END, sunDot);
+  // Coarse FBM captures large population clusters; fine FBM adds sub-city variation
+  let cityCoarse = fbmCity(vec2f(lat * 6.0,  lon * 8.0));
+  let cityFine   = fbmCity(vec2f(lat * 25.0 + 1.7, lon * 19.0 + 2.3));
+  // Coastal elevation bias: cities cluster near coasts and river-delta plains
+  let coastalBias = smoothstep(0.44, 0.52, height) * (1.0 - smoothstep(0.52, 0.76, height));
+  // Latitude weighting: favour temperate zones ~20°-60° (less near equator/poles)
+  let absLat = abs(lat) / (PI / 2.0);
+  let latWeight = smoothstep(0.07, 0.22, absLat) * (1.0 - smoothstep(0.60, 0.80, absLat));
+  // Final density: land × coastal × latitude × FBM cluster threshold
+  let cityDensity = f32(isLand) * coastalBias * latWeight * smoothstep(0.38, 0.58, cityCoarse);
+  let cityMask = cityDensity * (0.55 + 0.45 * cityFine);
+  // Warm sodium-vapour lights + cool LED cores in dense centres + faint blue atmospheric haze
+  let warmLight = vec3f(1.0, 0.78, 0.28) * cityMask;
+  let coolLight = vec3f(0.9, 0.95, 1.0) * pow(cityMask, 2.5) * 0.45;
+  let cityHaze  = vec3f(0.15, 0.20, 0.40) * cityMask * 0.35;
+  return (warmLight + coolLight + cityHaze) * night * 0.18;
+}
+`;

--- a/src/webgl/WebGLRenderer.ts
+++ b/src/webgl/WebGLRenderer.ts
@@ -252,6 +252,8 @@ export class WebGLRenderer {
     gl.uniformMatrix4fv(this.starU.loc('uInvViewProj'), false, invViewProj);
     gl.uniform1f(this.starU.loc('uTime'), frame.time);
     gl.uniform1i(this.starU.loc('uBackgroundMode'), frame.backgroundMode | 0);
+    gl.uniform3f(this.starU.loc('uCameraPos'), frame.cameraPos[0], frame.cameraPos[1], frame.cameraPos[2]);
+    gl.uniform3fv(this.starU.loc('uSunDir'), frame.sunDir);
     gl.bindVertexArray(this.fsTriangle);
     gl.drawArrays(gl.TRIANGLES, 0, 3);
     gl.bindVertexArray(null);

--- a/src/webgl/shaders.ts
+++ b/src/webgl/shaders.ts
@@ -280,12 +280,61 @@ in vec2 vNdc;
 uniform mat4 uInvViewProj;
 uniform float uTime;
 uniform int uBackgroundMode;
+uniform vec3 uCameraPos;
+uniform vec3 uSunDir;
 out vec4 fragColor;
 
 float hash21(vec2 p) {
   p = fract(p * vec2(123.34, 456.21));
   p += dot(p, p + 45.32);
   return fract(p.x * p.y);
+}
+
+// Small 2-octave value noise for the ground-view horizon terrain fill.
+float vnoise21(vec2 p) {
+  vec2 i = floor(p);
+  vec2 f = fract(p);
+  vec2 u = f * f * (3.0 - 2.0 * f);
+  float a = mix(hash21(i), hash21(i + vec2(1, 0)), u.x);
+  float b = mix(hash21(i + vec2(0, 1)), hash21(i + vec2(1, 1)), u.x);
+  return mix(a, b, u.y);
+}
+
+// Ground View (backgroundMode 2): simplified horizon matching the WebGPU
+// ray-traced horizon pass — terrain fill below the geometric horizon,
+// haze band + night city-light glow above it.
+vec3 groundViewHorizon(vec3 color, vec3 dir) {
+  float r = max(length(uCameraPos), 6371.0 + 1.0);
+  vec3 up = uCameraPos / r;
+  float cosH = -sqrt(max(1.0 - (6371.0 * 6371.0) / (r * r), 0.0));
+  float cosVZ = dot(dir, up);
+  float sunElev = dot(up, normalize(uSunDir));
+  float day = smoothstep(-0.08, 0.25, sunElev);
+  float night = smoothstep(0.02, -0.10, sunElev);
+  float twilight = smoothstep(-0.28, -0.05, sunElev) * (1.0 - smoothstep(-0.02, 0.14, sunElev));
+
+  if (cosVZ < cosH) {
+    // Below the horizon: procedural terrain fill with night city speckle.
+    vec2 gp = vec2(atan(dir.y, dir.x), asin(clamp(dir.z, -1.0, 1.0))) * 40.0;
+    float n = vnoise21(gp) * 0.65 + vnoise21(gp * 2.7) * 0.35;
+    vec3 land = mix(vec3(0.020, 0.030, 0.028), vec3(0.10, 0.12, 0.09), n);
+    vec3 ground = land * (0.10 + 0.90 * day);
+    float city = step(0.985, hash21(floor(gp * 5.0))) * night * step(0.45, n);
+    ground += vec3(1.0, 0.70, 0.30) * city * 0.55;
+    // Haze just below the horizon line.
+    float hb = exp(-(cosH - cosVZ) * 30.0);
+    ground = mix(ground, mix(vec3(0.04, 0.06, 0.11), vec3(0.40, 0.52, 0.72), day), hb * 0.75);
+    ground += vec3(0.9, 0.35, 0.10) * twilight * hb * 0.4;
+    return ground;
+  }
+
+  // Above the horizon: Mie haze band + night city glow hugging the line.
+  float band = exp(-(cosVZ - cosH) * 16.0);
+  vec3 haze = mix(vec3(0.03, 0.05, 0.10), vec3(0.35, 0.50, 0.80), day);
+  haze += vec3(1.0, 0.42, 0.14) * twilight * 0.8;
+  float clump = vnoise21(vec2(atan(dir.y, dir.x) * 10.0, 1.7));
+  vec3 cityGlow = vec3(1.0, 0.60, 0.28) * band * band * night * (0.20 + 0.35 * clump);
+  return mix(color, haze, band * 0.7) + cityGlow;
 }
 
 void main() {
@@ -310,7 +359,11 @@ void main() {
   bright = min(bright, starCap);
   // Subtle deep-space gradient.
   vec3 bg = mix(vec3(0.004, 0.006, 0.015), vec3(0.0, 0.0, 0.004), uv.y * 0.5 + 0.5);
-  fragColor = vec4(bg + vec3(bright), 1.0);
+  vec3 color = bg + vec3(bright);
+  if (uBackgroundMode == 2) {
+    color = groundViewHorizon(color, dir);
+  }
+  fragColor = vec4(color, 1.0);
 }
 `;
 


### PR DESCRIPTION
## Summary

Ground View's terrain pass was a flat two-color gradient (`ground.ts`) — the biggest visual gap versus the photoreal Earth limb, city lights, and starfield of the other modes. This PR replaces it with a screen-space horizon reconstruction that matches the orbital Earth shader, without drawing the full Earth sphere.

## Changes

### Screen-space horizon reconstruction (`src/shaders/render/ground.ts`)
- A single fullscreen quad ray-traces the Earth from the observer position. Per-pixel view rays are rebuilt from the shared `view_proj` matrix (camera basis + FOV extracted from the matrix rows), so no new uniforms are needed for the ray math.
- Rays that hit the Earth sample the same procedural FBM terrain, biome palette, snow line, terminator twilight band, and night-side city lights as the orbital Earth shader — the horizon matches the globe at all five presets, including the curved limb from the higher presets (airplane, beach).
- Rays that miss get a sky treatment: day/night gradient, twilight scatter toward the sun's azimuth, a Mie haze band from the existing `atmosphereLUT` bindings, and a clumpy warm **night-side city-light glow band** hugging the horizon. Sky pixels output low alpha so the real starfield (now drawn beneath in the ground pass) shows through.

### Shared terrain WGSL module (`src/shaders/render/terrainCommon.ts`)
- Extracted `noise3d`/`fbmTerrain`/`biomeColor`/`fbmCity`/`schlickFresnel` and related constants from `earth.ts` into a shared module used by both shaders.
- City lights are now emitted from a shared `cityLightEmission()` so Ground View night lights match the Earth shader exactly.

### Render pipeline (`src/render/RenderPipeline.ts`)
- `encodeGroundScenePass` now draws **stars → horizon quad → satellites → beams**; the full Earth sphere + atmosphere mesh draw is removed from the ground pass (fullscreen quad only, keeping Ground View within its tuning budget).
- New 16-byte `GroundParams` uniform (`oceanBias`, `urbanGlow`, `overlayFade`, `hazeBoost`) bound alongside the atmosphere LUT; `setGroundViewParams` only writes on change.

### Preset-aware horizon bias (`src/camera/GroundObserverCamera.ts`, `src/main.ts`)
- Each ground preset carries `horizon` settings: **Beach** sinks terrain toward open ocean and gets Fresnel sun glint + animated night sparkle shimmer; **Rooftop** gets the strongest urban glow band; **House/Car** fade the terrain pass over the lower third where the CSS frame overlay (sill/dashboard) covers it. `hazeBoost` reuses the preset's existing `atmosphericScatter`.

### WebGL fallback (`src/webgl/shaders.ts`, `WebGLRenderer.ts`)
- The fullscreen star shader gains a simplified matching horizon for ground view: procedural terrain fill with night city speckle below the geometric horizon, haze band + twilight + night city glow above it (driven by new `uCameraPos`/`uSunDir` uniforms).

## Acceptance criteria
- ✅ Believable ray-traced horizon (curved limb, terrain/ocean biomes) at all five presets — no flat gradient
- ✅ Night city lights on the terrain and as a glow band along the horizon when the sun is below the limb
- ✅ No full Earth sphere draw in the ground pass — one fullscreen quad + existing star/satellite/beam draws
- ✅ WebGL fallback gets a simplified but matching horizon treatment

## Testing
- `npm run type-check` clean; `npm test` 63/63 passing; `npm run build` succeeds
- All three composed WGSL shaders (`ground`, `earth`, `stars`) validated with `naga`
- Updated GLSL star shader compiled successfully in headless Chromium WebGL2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QaAQVCpyhfQv3QsVkMEwVh

---
_Generated by [Claude Code](https://claude.ai/code/session_01QaAQVCpyhfQv3QsVkMEwVh)_