### PR TITLE
Fix type-check failure in RenderPipeline closure narrowing

### DIFF
--- a/src/render/RenderPipeline.ts
+++ b/src/render/RenderPipeline.ts
@@ -1137,6 +1137,7 @@ export class RenderPipeline {
     moonView = false,
   ): void {
     if (!this.pipelines || !this.bindGroups || !this.renderTargets) return;
+    const { pipelines, bindGroups } = this;
 
     const pass = encoder.beginRenderPass({
       colorAttachments: [{
@@ -1162,16 +1163,16 @@ export class RenderPipeline {
     pass.draw(3);
 
     const drawEarth = (): void => {
-      pass.setPipeline(this.pipelines.earth);
-      pass.setBindGroup(0, this.bindGroups.earth);
+      pass.setPipeline(pipelines.earth);
+      pass.setBindGroup(0, bindGroups.earth);
       pass.setVertexBuffer(0, earthVertexBuffer);
       pass.setIndexBuffer(earthIndexBuffer, 'uint32');
       pass.drawIndexed(earthIndexCount);
     };
 
     const drawAtmosphere = (): void => {
-      pass.setPipeline(this.pipelines.atmosphere);
-      pass.setBindGroup(0, this.bindGroups.atmosphere);
+      pass.setPipeline(pipelines.atmosphere);
+      pass.setBindGroup(0, bindGroups.atmosphere);
       pass.setVertexBuffer(0, earthVertexBuffer);
       pass.setIndexBuffer(earthIndexBuffer, 'uint32');
       pass.drawIndexed(earthIndexCount);


### PR DESCRIPTION
## Summary

`npm run type-check` (and therefore the Test workflow) was failing on `main` with four `TS2531: Object is possibly 'null'` errors in `src/render/RenderPipeline.ts`. TypeScript cannot carry the null-narrowing of `this.pipelines` / `this.bindGroups` from the guard at the top of `encodeScenePass` into the `drawEarth` / `drawAtmosphere` arrow functions, since a closure may run after the fields change.

The fix captures the narrowed references as locals immediately after the guard and uses those inside the closures. No behavior change.

## Validation

- `npm run type-check` — clean
- `npm test` — 103/103 passing
- `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HG3LWcjgNvrLDSEwzmmPx5

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG3LWcjgNvrLDSEwzmmPx5)_