### PR TITLE
Add computerized LED/laser/spot displays to skyline buildings

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,6 +214,64 @@
         </button>
       </section>
 
+      <section
+        id="skyline-display-controls"
+        class="control-group"
+        style="display: none"
+        aria-label="Skyline Building Displays"
+      >
+        <div class="anim-label">CITY DISPLAYS</div>
+        <div class="pattern-title" id="skylineDisplayName">CITY DISPLAYS • AUTO</div>
+        <button
+          class="skyline-display-btn active"
+          id="skyDisp0"
+          data-display="0"
+          aria-label="Automatic mix of building display types"
+        >
+          AUTO
+        </button>
+        <button
+          class="skyline-display-btn"
+          id="skyDisp1"
+          data-display="1"
+          aria-label="LED matrix media facades"
+        >
+          LED
+        </button>
+        <button
+          class="skyline-display-btn"
+          id="skyDisp2"
+          data-display="2"
+          aria-label="Laser scan displays"
+        >
+          LASER
+        </button>
+        <button
+          class="skyline-display-btn"
+          id="skyDisp3"
+          data-display="3"
+          aria-label="Moving spotlight displays"
+        >
+          SPOTS
+        </button>
+        <button
+          class="skyline-display-btn"
+          id="skyDisp4"
+          data-display="4"
+          aria-label="Neon strip displays"
+        >
+          NEON
+        </button>
+        <button
+          class="skyline-display-btn"
+          id="skyDisp5"
+          data-display="5"
+          aria-label="All building display types at full intensity"
+        >
+          ALL
+        </button>
+      </section>
+
       <section id="tle-catalog-controls" class="control-group" aria-label="Satellite Catalog">
         <div class="physics-label">SATELLITE CATALOG</div>
         <select id="tleCatalogPicker" aria-label="Select satellite TLE catalog">

--- a/package-lock.json
+++ b/package-lock.json
@@ -355,6 +355,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -372,6 +390,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -387,6 +423,24 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -804,9 +858,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -824,9 +875,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -844,9 +892,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -864,9 +909,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -884,9 +926,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -904,9 +943,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -924,9 +960,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -944,9 +977,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1193,9 +1223,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1210,9 +1237,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1227,9 +1251,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1244,9 +1265,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1261,9 +1279,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1278,9 +1293,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1295,9 +1307,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1312,9 +1321,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4347,6 +4353,420 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/vitest/node_modules/@vitest/mocker": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
@@ -4372,6 +4792,50 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/vitest/node_modules/vite": {

--- a/src/app/AppCallbackBinder.ts
+++ b/src/app/AppCallbackBinder.ts
@@ -12,6 +12,7 @@ import {
   setupAnimationPatternButtons,
   setupPhysicsButtons,
 } from '@/app/PatternController.js';
+import { setupSkylineDisplayButtons } from '@/app/SkylineDisplayController.js';
 import { setRealismMode } from '@/app/RealismController.js';
 import { switchTLECatalog } from '@/app/loadSatelliteOrbitalData.js';
 import { bindSimClock } from '@/app/SimClockController.js';
@@ -144,6 +145,7 @@ export function setupCallbacks(rt: AppRuntime): void {
   setupAnimationPatternButtons(rt);
   setupPhysicsButtons(rt);
   setupGroundPresetButtons(rt);
+  setupSkylineDisplayButtons(rt);
 
   rt.ui.createSimTransport(() => rt.simulation.clock);
   rt.ui.updateSimClock(rt.simulation.clock);

--- a/src/app/FrameLoop.ts
+++ b/src/app/FrameLoop.ts
@@ -234,6 +234,7 @@ export function createWebGPURenderLoop(rt: AppRuntime): (timestamp: number) => v
         nightFactor,
         simTime,
         skylineEmissiveScale(rt.view.imageTuning.coreBoost),
+        rt.simulation.skylineDisplayMode,
       );
       rt.pipeline.encodeSkylinePass(encoder, rt.skyline.buildingCount);
     }

--- a/src/app/GroundObserverUI.ts
+++ b/src/app/GroundObserverUI.ts
@@ -1,5 +1,6 @@
 import type { GroundObserverPreset } from '@/camera/GroundObserverCamera.js';
 import type { AppRuntime } from '@/app/AppRuntime.js';
+import { updateSkylineDisplayControlsVisibility } from '@/app/SkylineDisplayController.js';
 
 export function setupGroundPresetButtons(rt: AppRuntime): void {
   const presetButtons = document.querySelectorAll('.preset-btn');
@@ -48,6 +49,8 @@ export function updateGroundObserverOverlay(rt: AppRuntime): void {
   } else if (isSkyline) {
     rt.applyGroundOverlayClass('frame-skyline');
   }
+
+  updateSkylineDisplayControlsVisibility(rt);
 }
 
 export function applyGroundOverlayClass(_rt: AppRuntime, overlayClass: string): void {

--- a/src/app/SimulationState.ts
+++ b/src/app/SimulationState.ts
@@ -17,6 +17,8 @@ export class SimulationState {
   currentAnimationPattern = 0;
   currentPhysicsMode = 0;
   realismMode = false;
+  /** Skyline view: 0=auto mix, 1=LED, 2=laser, 3=spots, 4=neon, 5=all */
+  skylineDisplayMode: 0 | 1 | 2 | 3 | 4 | 5 = 0;
   hasTleCatalog = false;
   patternSeed = 0;
   patternAnimationStart = 0;

--- a/src/app/SkylineDisplayController.ts
+++ b/src/app/SkylineDisplayController.ts
@@ -1,0 +1,37 @@
+import type { AppRuntime } from '@/app/AppRuntime.js';
+import type { SkylineDisplayMode } from '@/render/SkylineCity.js';
+
+const DISPLAY_LABELS = ['AUTO', 'LED', 'LASER', 'SPOTS', 'NEON', 'ALL'] as const;
+
+export function setupSkylineDisplayButtons(rt: AppRuntime): void {
+  const buttons = document.querySelectorAll('.skyline-display-btn');
+  buttons.forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      const target = e.target as HTMLButtonElement;
+      const mode = parseInt(target.dataset.display || '0', 10) as SkylineDisplayMode;
+      setSkylineDisplayMode(rt, mode);
+      buttons.forEach((b) => b.classList.remove('active'));
+      target.classList.add('active');
+    });
+  });
+}
+
+export function setSkylineDisplayMode(rt: AppRuntime, mode: SkylineDisplayMode): void {
+  if (mode < 0 || mode > 5) return;
+  rt.simulation.skylineDisplayMode = mode;
+  updateSkylineDisplayTitle(rt);
+  console.log(`🏙️ Skyline displays: ${DISPLAY_LABELS[mode]}`);
+}
+
+export function updateSkylineDisplayTitle(rt: AppRuntime): void {
+  const title = document.getElementById('skylineDisplayName');
+  if (title) {
+    title.textContent = `CITY DISPLAYS • ${DISPLAY_LABELS[rt.simulation.skylineDisplayMode]}`;
+  }
+}
+
+export function updateSkylineDisplayControlsVisibility(rt: AppRuntime): void {
+  const section = document.getElementById('skyline-display-controls');
+  if (!section) return;
+  section.style.display = rt.camera.getViewMode() === 'skyline' ? 'block' : 'none';
+}

--- a/src/render/SkylineCity.test.ts
+++ b/src/render/SkylineCity.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { DEFAULT_SKYLINE, SkylineCity } from './SkylineCity.js';
+import {
+  DEFAULT_SKYLINE,
+  SkylineCity,
+  packFacadeMeta,
+  unpackFacadeMeta,
+  SKYLINE_DISPLAY,
+} from './SkylineCity.js';
 
 describe('SkylineCity', () => {
   it('generates the configured building count with deterministic layout', () => {
@@ -9,20 +15,48 @@ describe('SkylineCity', () => {
     expect(b.buildingCount).toBe(260);
   });
 
+  it('packs and unpacks facade metadata', () => {
+    expect(unpackFacadeMeta(packFacadeMeta(1, SKYLINE_DISPLAY.LASER_SCAN))).toEqual({
+      roofEquip: 1,
+      displayType: SKYLINE_DISPLAY.LASER_SCAN,
+    });
+    expect(unpackFacadeMeta(packFacadeMeta(0, SKYLINE_DISPLAY.LED_MATRIX))).toEqual({
+      roofEquip: 0,
+      displayType: SKYLINE_DISPLAY.LED_MATRIX,
+    });
+  });
+
   it('marks roughly the tallest decile for rooftop equipment', () => {
     const city = new SkylineCity({ seed: 99, buildingCount: 100 });
     const data = (city as unknown as { buildingData: Float32Array }).buildingData;
     let equipCount = 0;
     let tallCount = 0;
     for (let i = 0; i < 100; i++) {
+      const meta = unpackFacadeMeta(data[i * 8 + 7]);
       const h = data[i * 8 + 4];
-      const equip = data[i * 8 + 7];
       if (h > 0) tallCount++;
-      if (equip > 0.5) equipCount++;
+      if (meta.roofEquip) equipCount++;
     }
     expect(equipCount).toBeGreaterThanOrEqual(8);
     expect(equipCount).toBeLessThanOrEqual(12);
     expect(tallCount).toBeGreaterThan(equipCount);
+  });
+
+  it('assigns computerized displays to a meaningful subset of buildings', () => {
+    const city = new SkylineCity({ seed: 11, buildingCount: 120 });
+    const data = (city as unknown as { buildingData: Float32Array }).buildingData;
+    let displayCount = 0;
+    const types = new Set<number>();
+    for (let i = 0; i < 120; i++) {
+      const meta = unpackFacadeMeta(data[i * 8 + 7]);
+      if (meta.displayType !== SKYLINE_DISPLAY.NONE) {
+        displayCount++;
+        types.add(meta.displayType);
+      }
+    }
+    expect(displayCount).toBeGreaterThanOrEqual(18);
+    expect(displayCount).toBeLessThanOrEqual(40);
+    expect(types.size).toBeGreaterThanOrEqual(3);
   });
 
   it('keeps the street clearance zone free of buildings', () => {

--- a/src/render/SkylineCity.ts
+++ b/src/render/SkylineCity.ts
@@ -23,6 +23,36 @@ import {
 /** Floats per Building instance (must match the 32-byte WGSL struct). */
 const BUILDING_FLOATS = 8;
 
+/**
+ * Per-building computerized display kinds packed into `facadeMeta` with roofEquip:
+ *   facadeMeta = roofEquip (0|1) + displayType * 2
+ */
+export const SKYLINE_DISPLAY = {
+  NONE: 0,
+  LED_MATRIX: 1,
+  LASER_SCAN: 2,
+  SPOTLIGHTS: 3,
+  NEON_STRIPS: 4,
+  SPECTACULAR: 5,
+} as const;
+
+export type SkylineDisplayType = (typeof SKYLINE_DISPLAY)[keyof typeof SKYLINE_DISPLAY];
+
+/** UI filter: 0 = auto mix, 1–4 = single family, 5 = all displays at full intensity. */
+export type SkylineDisplayMode = 0 | 1 | 2 | 3 | 4 | 5;
+
+export function packFacadeMeta(roofEquip: 0 | 1, displayType: SkylineDisplayType): number {
+  return roofEquip + displayType * 2;
+}
+
+export function unpackFacadeMeta(meta: number): { roofEquip: 0 | 1; displayType: SkylineDisplayType } {
+  const packed = Math.round(meta);
+  return {
+    roofEquip: (packed % 2) as 0 | 1,
+    displayType: Math.floor(packed / 2) as SkylineDisplayType,
+  };
+}
+
 /** Bytes in the CityUni uniform (mat4x4f + vec4f + vec4f + vec4f = 112 bytes). */
 const CITY_UNI_BYTES = 112;
 
@@ -120,11 +150,17 @@ export class SkylineCity {
       this.buildingData[o + 7] = 0;
     }
 
-    // Mark tallest decile for rooftop equipment silhouettes.
+    // Mark tallest decile for rooftop equipment silhouettes, then assign LED/laser displays.
     const heights: number[] = [];
+    const candidates: { index: number; prominence: number }[] = [];
     for (let i = 0; i < this.buildingCount; i++) {
-      const h = this.buildingData[i * BUILDING_FLOATS + 4];
-      if (h > 0) heights.push(h);
+      const o = i * BUILDING_FLOATS;
+      const h = this.buildingData[o + 4];
+      if (h > 0) {
+        heights.push(h);
+        const footprint = this.buildingData[o + 2] * this.buildingData[o + 3];
+        candidates.push({ index: i, prominence: h * Math.sqrt(footprint) });
+      }
     }
     heights.sort((a, b) => a - b);
     const threshold = heights[Math.floor(heights.length * 0.9)] ?? this.config.maxHeightKm;
@@ -132,8 +168,37 @@ export class SkylineCity {
       const o = i * BUILDING_FLOATS;
       const h = this.buildingData[o + 4];
       if (h >= threshold && h > 0) {
-        this.buildingData[o + 7] = 1;
+        this.buildingData[o + 7] = packFacadeMeta(1, SKYLINE_DISPLAY.NONE);
       }
+    }
+
+    candidates.sort((a, b) => b.prominence - a.prominence);
+    const displayQuota = Math.max(18, Math.floor(candidates.length * 0.28));
+    const displayRng = mulberry32(this.config.seed ^ 0x1edfacade);
+    for (let rank = 0; rank < displayQuota && rank < candidates.length; rank++) {
+      const { index } = candidates[rank]!;
+      const o = index * BUILDING_FLOATS;
+      const h = this.buildingData[o + 4];
+      const width = this.buildingData[o + 2];
+      const depth = this.buildingData[o + 3];
+      const footprint = width * depth;
+      const { roofEquip } = unpackFacadeMeta(this.buildingData[o + 7]);
+
+      let displayType: SkylineDisplayType = SKYLINE_DISPLAY.NONE;
+      if (rank < 4) {
+        displayType =
+          displayRng() < 0.55 ? SKYLINE_DISPLAY.SPECTACULAR : SKYLINE_DISPLAY.LASER_SCAN;
+      } else if (footprint > this.config.maxFootprintKm * this.config.minFootprintKm * 0.82) {
+        displayType = SKYLINE_DISPLAY.LED_MATRIX;
+      } else if (h > this.config.maxHeightKm * 0.62 && roofEquip) {
+        displayType = SKYLINE_DISPLAY.SPOTLIGHTS;
+      } else if (displayRng() < 0.42) {
+        displayType = SKYLINE_DISPLAY.NEON_STRIPS;
+      } else {
+        displayType = SKYLINE_DISPLAY.LED_MATRIX;
+      }
+
+      this.buildingData[o + 7] = packFacadeMeta(roofEquip, displayType);
     }
   }
 
@@ -227,6 +292,7 @@ export class SkylineCity {
     nightFactor: number,
     time: number,
     emissiveBoost = 1.0,
+    displayMode: SkylineDisplayMode = 0,
   ): void {
     if (!this.cityUniformBuffer) return;
 
@@ -253,7 +319,7 @@ export class SkylineCity {
     tail[8] = camEnu[0];
     tail[9] = camEnu[1];
     tail[10] = camEnu[2];
-    tail[11] = 0;
+    tail[11] = displayMode;
 
     device.queue.writeBuffer(this.cityUniformBuffer, 0, data);
   }

--- a/src/shaders/render/skyline.ts
+++ b/src/shaders/render/skyline.ts
@@ -10,7 +10,8 @@
  * - Soft window masks + HDR cores clamped 2.0–2.85 for cohesive bloom halos
  * - Exponential depth fog with distant warm city bleed
  * - Street-level sodium strips + retail spill at building bases
- * - Rooftop equipment silhouettes on tallest decile (roofEquip flag)
+ * - Rooftop equipment silhouettes on tallest decile (facadeMeta bit 0)
+ * - Computerized facade displays: LED matrix, laser scan, spotlights, neon strips
  * - Fresnel sky-gradient glass reflection on dark facades
  * - Facade corner AO + recessed mullion depth
  */
@@ -26,14 +27,14 @@ struct Building {
   height     : f32,   // extrusion height, km
   colorSeed  : f32,   // window tint variation seed
   windowSeed : f32,   // window on/off pattern seed
-  roofEquip  : f32,   // 1.0 = tallest decile — rooftop HVAC silhouettes
+  facadeMeta : f32,   // roofEquip (meta%2) + displayType*2
 };
 
 struct CityUni {
   city_view_proj : mat4x4f,
   sun_dir_enu    : vec4f,
   params         : vec4f, // x = nightFactor, y = buildingCount, z = time, w = emissiveBoost
-  camera_enu     : vec4f, // xyz = observer eye in local ENU (km)
+  camera_enu     : vec4f, // xyz = observer eye in local ENU (km), w = displayMode filter
 };
 
 @group(0) @binding(1) var<uniform> city : CityUni;
@@ -47,6 +48,7 @@ struct VOut {
   @location(3) worldPos : vec3f,
   @location(4) bldgHeight : f32,
   @location(5) roofEquip : f32,
+  @location(6) displayType : f32,
 };
 
 const CUBE_POS = array<vec3f, 36>(
@@ -107,6 +109,166 @@ fn facadeCornerAO(cellU : f32, cellV : f32) -> f32 {
   return mix(0.72, 1.0, smoothstep(0.0, 0.12, min(edgeU, edgeV) * 4.0));
 }
 
+fn unpackFacadeMeta(meta : f32) -> vec2f {
+  let packed = i32(meta + 0.25);
+  return vec2f(f32(packed % 2), f32(packed / 2));
+}
+
+fn displayModeWeight(displayType : f32, filterMode : f32) -> f32 {
+  if (filterMode < 0.5) {
+  // Auto — full strength for every assigned display.
+    return 1.0;
+  }
+  if (filterMode > 4.5) {
+  // All — boost every display type.
+    return 1.35;
+  }
+  return select(0.12, 1.0, abs(displayType - filterMode) < 0.5);
+}
+
+fn ledMatrixDisplay(
+  cellU : f32,
+  cellV : f32,
+  cellIdU : f32,
+  cellIdV : f32,
+  heightNorm : f32,
+  seed : vec2f,
+  time : f32,
+) -> vec3f {
+  let band = smoothstep(0.22, 0.34, heightNorm) * (1.0 - smoothstep(0.82, 0.94, heightNorm));
+  let centerU = smoothstep(0.08, 0.22, cellU) * (1.0 - smoothstep(0.78, 0.92, cellU));
+  if (band * centerU < 0.02) {
+    return vec3f(0.0);
+  }
+
+  let pixelU = floor(cellIdU * 0.55 + seed.x * 3.0);
+  let pixelV = floor(cellIdV * 0.42 + seed.y * 5.0);
+  let pxU = fract(cellIdU * 0.55 + seed.x * 3.0);
+  let pxV = fract(cellIdV * 0.42 + seed.y * 5.0);
+  let pixelMask = smoothstep(0.10, 0.18, pxU) * smoothstep(0.90, 0.82, pxU)
+                * smoothstep(0.12, 0.20, pxV) * smoothstep(0.88, 0.80, pxV);
+
+  let scroll = floor(time * 2.4 + seed.x * 11.0);
+  let wave = sin(time * 1.7 + pixelU * 0.9 + pixelV * 0.35 + seed.y * 9.0);
+  let checker = fract((pixelU + pixelV + scroll) * 0.5);
+  let glyph = step(0.58, hash21(vec2f(pixelU + scroll * 0.17, pixelV) + seed * 4.1));
+  let pattern = mix(checker, glyph, 0.55 + 0.35 * wave);
+
+  let hue = fract(seed.x * 0.37 + time * 0.08 + pixelU * 0.04);
+  let rgbA = vec3f(0.15, 0.85, 1.0);
+  let rgbB = vec3f(1.0, 0.18, 0.72);
+  let rgbC = vec3f(0.25, 1.0, 0.45);
+  var tint = mix(rgbA, rgbB, smoothstep(0.2, 0.8, hue));
+  tint = mix(tint, rgbC, step(0.72, hue) * 0.65);
+
+  let core = (2.8 + pattern * 1.6) * pixelMask * band * centerU;
+  return tint * core;
+}
+
+fn laserScanDisplay(
+  cellU : f32,
+  heightNorm : f32,
+  seed : vec2f,
+  time : f32,
+) -> vec3f {
+  let band = smoothstep(0.08, 0.18, heightNorm) * (1.0 - smoothstep(0.92, 0.98, heightNorm));
+  let scanAxis = fract(seed.x * 3.7) > 0.45;
+  let scanPos = fract(time * (0.11 + seed.y * 0.07) + seed.x * 5.3);
+  let coord = select(heightNorm, cellU, scanAxis);
+  let line = exp(-pow((coord - scanPos) * 42.0, 2.0));
+  let trail = exp(-pow((coord - fract(scanPos + 0.08)) * 28.0, 2.0)) * 0.35;
+  let hue = fract(time * 0.22 + seed.y * 0.41);
+  let laserColor = mix(vec3f(0.2, 1.0, 1.0), vec3f(1.0, 0.2, 0.95), step(0.5, hue));
+  return laserColor * (line + trail) * band * 3.6;
+}
+
+fn spotlightDisplay(
+  cellU : f32,
+  heightNorm : f32,
+  seed : vec2f,
+  time : f32,
+) -> vec3f {
+  var glow = vec3f(0.0);
+  for (var i = 0; i < 3; i++) {
+    let fi = f32(i);
+    let spotU = fract(time * (0.05 + fi * 0.018) + seed.x * (1.7 + fi * 2.3) + fi * 0.31);
+    let spotV = fract(time * (0.04 + fi * 0.012) + seed.y * (2.1 + fi * 1.9) + fi * 0.47);
+    let du = cellU - spotU;
+    let dv = heightNorm - spotV;
+    let spot = exp(-(du * du + dv * dv) * 180.0);
+    let tint = mix(vec3f(1.0, 0.95, 0.82), vec3f(0.75, 0.88, 1.0), fi * 0.5);
+    glow += tint * spot * (2.6 - fi * 0.35);
+  }
+  return glow;
+}
+
+fn neonStripDisplay(
+  cellU : f32,
+  cellIdV : f32,
+  heightNorm : f32,
+  seed : vec2f,
+  time : f32,
+) -> vec3f {
+  let stripCount = 3.0 + floor(seed.x * 4.0);
+  let stripIdx = floor(heightNorm * stripCount + 0.2);
+  let stripCenter = (stripIdx + 0.5) / stripCount;
+  let stripLine = exp(-pow((heightNorm - stripCenter) * stripCount * 9.0, 2.0));
+  let edgeU = smoothstep(0.04, 0.12, cellU) * (1.0 - smoothstep(0.88, 0.96, cellU));
+  let pulse = 0.65 + 0.35 * sin(time * (1.4 + seed.y * 0.8) + stripIdx * 1.7);
+  let hue = fract(stripIdx * 0.21 + seed.y * 0.33 + time * 0.06);
+  let neonA = vec3f(1.0, 0.12, 0.55);
+  let neonB = vec3f(0.1, 0.95, 1.0);
+  let neonC = vec3f(1.0, 0.82, 0.18);
+  var tint = mix(neonA, neonB, smoothstep(0.15, 0.85, hue));
+  tint = mix(tint, neonC, step(0.78, hue));
+  return tint * stripLine * edgeU * pulse * 2.4;
+}
+
+fn spectacularDisplay(
+  cellU : f32,
+  cellV : f32,
+  cellIdU : f32,
+  cellIdV : f32,
+  heightNorm : f32,
+  seed : vec2f,
+  time : f32,
+) -> vec3f {
+  return ledMatrixDisplay(cellU, cellV, cellIdU, cellIdV, heightNorm, seed, time) * 0.85
+       + laserScanDisplay(cellU, heightNorm, seed + vec2f(1.3, 0.7), time) * 0.75
+       + spotlightDisplay(cellU, heightNorm, seed + vec2f(2.1, 1.9), time) * 0.55
+       + neonStripDisplay(cellU, cellIdV, heightNorm, seed + vec2f(0.4, 2.6), time) * 0.65;
+}
+
+fn facadeDisplayColor(
+  displayType : f32,
+  cellU : f32,
+  cellV : f32,
+  cellIdU : f32,
+  cellIdV : f32,
+  heightNorm : f32,
+  seed : vec2f,
+  time : f32,
+  modeWeight : f32,
+) -> vec3f {
+  if (displayType < 0.5 || modeWeight < 0.01) {
+    return vec3f(0.0);
+  }
+
+  var display = vec3f(0.0);
+  if (displayType < 1.5) {
+    display = ledMatrixDisplay(cellU, cellV, cellIdU, cellIdV, heightNorm, seed, time);
+  } else if (displayType < 2.5) {
+    display = laserScanDisplay(cellU, heightNorm, seed, time);
+  } else if (displayType < 3.5) {
+    display = spotlightDisplay(cellU, heightNorm, seed, time);
+  } else if (displayType < 4.5) {
+    display = neonStripDisplay(cellU, cellIdV, heightNorm, seed, time);
+  } else {
+    display = spectacularDisplay(cellU, cellV, cellIdU, cellIdV, heightNorm, seed, time);
+  }
+  return display * modeWeight;
+}
+
 @vertex
 fn vs(@builtin(vertex_index) vi : u32, @builtin(instance_index) ii : u32) -> VOut {
   let b = buildings[ii];
@@ -126,7 +288,9 @@ fn vs(@builtin(vertex_index) vi : u32, @builtin(instance_index) ii : u32) -> VOu
   out.instSeed = vec2f(b.colorSeed, b.windowSeed);
   out.worldPos = vec3f(worldX, worldY, worldZ);
   out.bldgHeight = b.height;
-  out.roofEquip = b.roofEquip;
+  let meta = unpackFacadeMeta(b.facadeMeta);
+  out.roofEquip = meta.x;
+  out.displayType = meta.y;
   return out;
 }
 
@@ -136,6 +300,8 @@ fn fs(in : VOut) -> @location(0) vec4f {
   let distKm = length(in.worldPos - cam);
   let night = city.params.x;
   let windowBoost = max(city.params.w, 0.5);
+  let displayFilter = city.camera_enu.w;
+  let displayWeight = displayModeWeight(in.displayType, displayFilter);
   let viewDir = normalize(cam - in.worldPos);
   let N = faceNormal(in.faceId);
   let fresnel = pow(1.0 - max(dot(normalize(viewDir), N), 0.0), 2.4);
@@ -214,6 +380,24 @@ fn fs(in : VOut) -> @location(0) vec4f {
   let recessShade = mix(0.58, 1.0, windowMask);
 
   var color = mix(facadeColor, windowColor * recessShade, windowLit * windowMask);
+
+  // Computerized facade displays — LED matrices, laser scans, spotlights, neon strips.
+  let displayGlow = facadeDisplayColor(
+    in.displayType,
+    cellU,
+    cellV,
+    cellIdU,
+    cellIdV,
+    heightNorm,
+    in.instSeed,
+    city.params.z,
+    displayWeight,
+  );
+  if (length(displayGlow) > 0.001) {
+    let displayMask = max(windowMask, 0.35);
+    color = mix(color, displayGlow, clamp(displayMask * night, 0.0, 1.0));
+    color += displayGlow * 0.18 * night;
+  }
 
   // Soft spill halo around lit panes — widens bloom footprint without raising core HDR.
   let spill = windowLit * windowMask * 0.14 * night;

--- a/src/shaders/shaderSources.test.ts
+++ b/src/shaders/shaderSources.test.ts
@@ -91,7 +91,14 @@ describe('shader source of truth', () => {
     expect(skyline).toContain('clamp((2.05');
     expect(skyline).toContain('sodium');
     expect(skyline).toContain('roofEquip');
-    expect(skyline).toContain('camera_enu');
+    expect(skyline).toContain('displayType');
+    expect(skyline).toContain('facadeMeta');
+    expect(skyline).toContain('fn ledMatrixDisplay');
+    expect(skyline).toContain('fn laserScanDisplay');
+    expect(skyline).toContain('fn spotlightDisplay');
+    expect(skyline).toContain('fn neonStripDisplay');
+    expect(skyline).toContain('fn facadeDisplayColor');
+    expect(skyline).toContain('displayFilter');
     expect(skyline).toContain('flicker');
     expect(skyline).toContain('recessShade');
   });

--- a/src/styles/panels.css
+++ b/src/styles/panels.css
@@ -591,6 +591,46 @@
   color: #fff;
 }
 
+.skyline-display-btn {
+  background: rgba(0, 220, 255, 0.06);
+  border: 1px solid rgba(0, 220, 255, 0.35);
+  color: #44e8ff;
+  padding: 7px 12px;
+  cursor: pointer;
+  font-family: 'Courier New', monospace;
+  font-size: 10px;
+  letter-spacing: 1px;
+  transition:
+    background 0.18s ease,
+    box-shadow 0.2s ease,
+    border-color 0.2s ease,
+    transform 0.15s ease,
+    color 0.18s ease;
+  pointer-events: auto;
+  margin: 1px 0;
+  border-radius: 8px;
+  min-height: 32px;
+  position: relative;
+}
+
+.skyline-display-btn:hover {
+  background: rgba(0, 220, 255, 0.18);
+  box-shadow:
+    0 0 10px rgba(0, 220, 255, 0.25),
+    inset 0 0 14px rgba(0, 220, 255, 0.12);
+  border-color: #44e8ff;
+  transform: translateY(-1px) scale(1.02);
+}
+
+.skyline-display-btn.active {
+  background: rgba(0, 220, 255, 0.2);
+  box-shadow:
+    0 0 14px rgba(0, 220, 255, 0.3),
+    0 0 4px rgba(0, 220, 255, 0.5) inset;
+  border-color: #44e8ff;
+  color: #fff;
+}
+
 /* Animation Extended Controls (Speed/Loop) */
 .animation-controls-extended {
   margin-top: 8px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends the Skyline view mode with animated computerized building displays layered on top of the existing window lighting.

- **Procedural assignment**: ~28% of prominent buildings get a display type based on height and footprint — LED matrix media facades, laser scans, moving spotlights, neon strips, or a spectacular combo on the tallest towers.
- **Shader effects**: New facade display functions in `skyline.ts` render scrolling LED pixels, sweeping laser lines, roaming spotlight pools, and pulsing neon bands with HDR cores for bloom.
- **UI controls**: A **CITY DISPLAYS** panel appears in Skyline view with AUTO / LED / LASER / SPOTS / NEON / ALL modes to filter or boost display families.

## Technical notes

- Building `facadeMeta` packs `roofEquip` + `displayType` into the existing 32-byte instance struct (no buffer size change).
- Display mode is passed via the unused `camera_enu.w` uniform component.
- Deterministic layout is preserved — same seed produces the same building/display assignment.

## Testing

- `npm run type-check` ✓
- `npm run test` ✓ (141 tests)
- `npm run build` ✓
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b191b31a-33e4-4e3e-b3ea-89fb82c47b8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b191b31a-33e4-4e3e-b3ea-89fb82c47b8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

