### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -705,3 +705,15 @@ main.ts (thin bootstrap)
     ├── MobilePresentation
     └── types/constants.ts
 ```
+
+## Cursor Cloud specific instructions
+
+Pure frontend Vite/TypeScript app; no backend, database, or external services. Node 22 and Python 3.12 are preinstalled. The startup update script runs `npm install`, so dependencies are already present when a session begins.
+
+Standard commands live in `package.json` (`dev`, `build`, `test`, `type-check`, `lint`, `test:visual`). Notes and caveats:
+
+- `npm run lint` (`eslint . && knip`) currently reports pre-existing errors in a few source files and exits non-zero. This is a known code-quality state, not an environment problem — don't treat it as a broken setup.
+- `npm run dev` serves on port 5173; `npm run test:visual` (Playwright) builds and previews on port 4173 with SwiftShader flags baked into `playwright.config.ts`.
+- Rendering the app in a real browser: WebGPU output is NOT readable in the headless/software-GPU browser here. Use the WebGL2 fallback via `?renderer=webgl` (optionally `&sats=200000` to reduce load). See `docs/WEBGL_FALLBACK.md`.
+- Interactive Chrome (computer-use) may report "WebGL2 is not supported". Fix by enabling `chrome://flags` → "Override software rendering list" and relaunching Chrome. Playwright visual tests don't need this (they already pass `--use-gl=angle --use-angle=swiftshader`).
+- Dismiss the first-run onboarding overlay ("START EXPLORING") before the simulation canvas is interactable.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for Grok Zephyr (WebGPU/WebGL orbital simulation) in Cursor Cloud and documents non-obvious startup caveats for future agents.

This is a pure frontend Vite/TypeScript app — no backend/DB/services. The startup update script is simply `npm install`.

### Verified

| Task | Command | Result |
| --- | --- | --- |
| Install | `npm install` | 181 packages, ok |
| Type-check | `npm run type-check` | pass |
| Unit tests | `npm run test` | 156 passed (29 files) |
| Build | `npm run build` | built in ~1.2s |
| Dev server | `npm run dev` | serves on `:5173` |
| Lint | `npm run lint` | tooling works; reports 4 pre-existing code errors (not env) |

### Hello-world (end-to-end)

Ran the app in Chrome via the documented WebGL2 fallback (`?renderer=webgl&sats=200000`), dismissed onboarding, and exercised core functionality: Earth + satellite constellation + starfield rendered, changed the camera to God View, and switched the beam pattern to GROK.

<a href="https://cursor.com/agents/bc-5b7e2327-a028-4bcd-bb80-d4529680e3ef/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgrok_zephyr_demo.mp4"><img src="https://cursor.com/artifacts/c/art-0910c5da-c92d-40ba-90bf-ca6d0fc3eae8" alt="grok_zephyr_demo.mp4" /></a>

![Simulation loaded](https://cursor.com/artifacts/c/art-b3bc13d5-c07b-420e-b511-5caff6cec6bf)
![God View](https://cursor.com/artifacts/c/art-b199ad7d-221f-46e0-b463-b67942e8848e)
![GROK beams](https://cursor.com/artifacts/c/art-9b1100dc-09d4-44ea-9269-dccda74ae134)

### Changes

- Added a `## Cursor Cloud specific instructions` section to `AGENTS.md` documenting: lint reports pre-existing errors, dev/preview ports, the WebGL2 fallback for viewing renders, the `chrome://flags` "Override software rendering list" caveat for interactive Chrome, and the onboarding overlay.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b7e2327-a028-4bcd-bb80-d4529680e3ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b7e2327-a028-4bcd-bb80-d4529680e3ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

