### PR TITLE
fix(xr): preserve the headset's off-axis eye frustum in stereo projection

### DIFF
--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -153,6 +153,45 @@ export function mat4persp(fovy: number, aspect: number, near: number, far: numbe
 }
 
 /**
+ * Create an off-axis (asymmetric) perspective projection from frustum bounds
+ * on the near plane (WebGPU style, z in [0, 1]).
+ *
+ * `mat4persp` is the special case where the bounds are symmetric; this form is
+ * needed for XR, where each eye's frustum is off-center.
+ */
+export function mat4frustum(
+  left: number,
+  right: number,
+  bottom: number,
+  top: number,
+  near: number,
+  far: number,
+): Mat4 {
+  const rl = 1 / (right - left);
+  const tb = 1 / (top - bottom);
+  const range = 1 / (near - far);
+
+  return new Float32Array([
+    2 * near * rl,
+    0,
+    0,
+    0,
+    0,
+    2 * near * tb,
+    0,
+    0,
+    (right + left) * rl,
+    (top + bottom) * tb,
+    far * range,
+    -1,
+    0,
+    0,
+    near * far * range,
+    0,
+  ]);
+}
+
+/**
  * Matrix multiplication (column-major)
  *
  * Returns a * b (apply b first, then a)

--- a/src/xr/XrAnchors.ts
+++ b/src/xr/XrAnchors.ts
@@ -64,12 +64,12 @@ export function stageMatrixFromCameraState(camera: CameraState): Float32Array {
 
 export function nextAnchorId(current: XrAnchorId): XrAnchorId {
   const i = XR_ANCHOR_IDS.indexOf(current);
-  return XR_ANCHOR_IDS[(i + 1) % XR_ANCHOR_IDS.length]!;
+  return XR_ANCHOR_IDS[(i + 1) % XR_ANCHOR_IDS.length];
 }
 
 export function previousAnchorId(current: XrAnchorId): XrAnchorId {
   const i = XR_ANCHOR_IDS.indexOf(current);
-  return XR_ANCHOR_IDS[(i - 1 + XR_ANCHOR_IDS.length) % XR_ANCHOR_IDS.length]!;
+  return XR_ANCHOR_IDS[(i - 1 + XR_ANCHOR_IDS.length) % XR_ANCHOR_IDS.length];
 }
 
 /** Default near/far for orbital XR projection rebuild (km). */

--- a/src/xr/XrPoseBridge.test.ts
+++ b/src/xr/XrPoseBridge.test.ts
@@ -55,3 +55,98 @@ describe('XrPoseBridge', () => {
     expect(Math.abs(rebuilt[14])).not.toBeCloseTo(Math.abs(xrProj[14]), 3);
   });
 });
+
+/**
+ * A headset eye frustum is off-axis: the lens axis sits away from the viewport
+ * centre, so left != -right. These bounds are near-plane tangents in the shape
+ * of a typical HMD's inner/outer asymmetry.
+ */
+function glEyeProjection(
+  left: number,
+  right: number,
+  bottom: number,
+  top: number,
+  near: number,
+  far: number,
+): Float32Array {
+  // WebXR runtimes emit GL-convention (z in [-1, 1]) projection matrices.
+  const rl = 1 / (right - left);
+  const tb = 1 / (top - bottom);
+  const nf = 1 / (near - far);
+  return new Float32Array([
+    2 * near * rl, 0, 0, 0,
+    0, 2 * near * tb, 0, 0,
+    (right + left) * rl, (top + bottom) * tb, (far + near) * nf, -1,
+    0, 0, 2 * far * near * nf, 0,
+  ]);
+}
+
+/** Project a view-space point and return NDC x/y (perspective divide). */
+function ndcXY(projection: Float32Array, p: [number, number, number]): [number, number] {
+  const [x, y, z] = p;
+  const cx = projection[0] * x + projection[4] * y + projection[8] * z + projection[12];
+  const cy = projection[1] * x + projection[5] * y + projection[9] * z + projection[13];
+  const cw = projection[3] * x + projection[7] * y + projection[11] * z + projection[15];
+  return [cx / cw, cy / cw];
+}
+
+describe('projectionFromXrFov preserves the headset frustum', () => {
+  // Off-axis: wider toward the nose than the temple, and slightly taller above.
+  const NEAR = 0.1;
+  const xrProj = glEyeProjection(-0.965 * NEAR, 0.78 * NEAR, -0.92 * NEAR, 1.01 * NEAR, NEAR, 1000);
+
+  it('keeps the frustum off-axis instead of symmetrising it', () => {
+    const rebuilt = projectionFromXrFov(xrProj, 1, 500000);
+    // A symmetric rebuild would zero these; they must survive.
+    expect(rebuilt[8]).toBeCloseTo(xrProj[8], 6);
+    expect(rebuilt[9]).toBeCloseTo(xrProj[9], 6);
+    expect(Math.abs(rebuilt[8])).toBeGreaterThan(0.01);
+  });
+
+  it('maps view-space rays to exactly the same NDC x/y as the headset matrix', () => {
+    const rebuilt = projectionFromXrFov(xrProj, 1, 500000);
+    // Points spread across the frustum, all in front of the eye (-z forward).
+    const samples: [number, number, number][] = [
+      [0, 0, -10],
+      [3, 2, -10],
+      [-4, 1.5, -25],
+      [2.5, -3, -7000],
+      [-1200, 800, -42164],
+    ];
+    for (const p of samples) {
+      const [ex, ey] = ndcXY(xrProj, p);
+      const [ax, ay] = ndcXY(rebuilt, p);
+      expect(ax).toBeCloseTo(ex, 5);
+      expect(ay).toBeCloseTo(ey, 5);
+    }
+  });
+
+  it('re-targets the depth range to orbital scale', () => {
+    const rebuilt = projectionFromXrFov(xrProj, 1, 500000);
+    const depth = (z: number): number => {
+      const cz = rebuilt[10] * z + rebuilt[14];
+      const cw = -z;
+      return cz / cw;
+    };
+    // WebGPU-style z in [0, 1] across the orbital range.
+    expect(depth(-1)).toBeCloseTo(0, 5);
+    expect(depth(-500000)).toBeCloseTo(1, 5);
+    // A GEO-distance satellite stays inside the frustum rather than clipping.
+    expect(depth(-42164)).toBeGreaterThan(0);
+    expect(depth(-42164)).toBeLessThan(1);
+  });
+
+  it('falls back to a symmetric perspective for degenerate input', () => {
+    const zero = new Float32Array(16);
+    expect(Number.isFinite(projectionFromXrFov(zero, 1, 500000)[0])).toBe(true);
+    const nan = glEyeProjection(-0.1, 0.1, -0.1, 0.1, 0.1, 1000);
+    nan[0] = Number.NaN;
+    expect(Number.isFinite(projectionFromXrFov(nan, 1, 500000)[0])).toBe(true);
+    // Mirrored bounds must not produce an inverted image.
+    const mirrored = glEyeProjection(-0.1, 0.1, -0.1, 0.1, 0.1, 1000);
+    mirrored[8] = 5; // pushes left past right
+    const out = projectionFromXrFov(mirrored, 1, 500000);
+    expect(Number.isFinite(out[0])).toBe(true);
+    expect(out[0]).toBeGreaterThan(0);
+  });
+});

--- a/src/xr/XrPoseBridge.ts
+++ b/src/xr/XrPoseBridge.ts
@@ -9,7 +9,7 @@
 import type { ViewDescriptor } from '@/camera/ViewDescriptor.js';
 import { viewDescriptorFromMatrices } from '@/camera/ViewDescriptor.js';
 import type { Vec3 } from '@/types/index.js';
-import { mat4inv, mat4mul, mat4persp } from '@/utils/math.js';
+import { mat4frustum, mat4inv, mat4mul, mat4persp } from '@/utils/math.js';
 import { XR_FAR_KM, XR_NEAR_KM } from '@/xr/XrAnchors.js';
 
 const M_TO_KM = 0.001;
@@ -71,8 +71,18 @@ export function cameraPosFromView(view: Float32Array): Vec3 {
 }
 
 /**
- * Rebuild a symmetric perspective from an XR projection matrix diagonal,
- * using orbital near/far in kilometers. Asymmetric FOV is approximated.
+ * Rebuild the eye projection with orbital near/far in kilometers, preserving
+ * the headset's exact frustum shape.
+ *
+ * Headset eye frusta are off-axis (the lens axis is not the viewport center),
+ * so collapsing them to a symmetric perspective skews binocular disparity and
+ * misaligns the stereo pair. Instead the four frustum tangents are recovered
+ * from the XR matrix and re-emitted against the orbital depth range.
+ *
+ * The entries read here (m00, m11, m[8], m[9]) are identical under both the
+ * GL z in [-1, 1] and WebGPU z in [0, 1] conventions -- only the depth row
+ * differs -- so this works regardless of which convention the runtime emits,
+ * and the result always uses the app-wide WebGPU-style convention.
  */
 export function projectionFromXrFov(
   xrProjection: Float32Array,
@@ -85,9 +95,30 @@ export function projectionFromXrFov(
   if (!Number.isFinite(m00) || !Number.isFinite(m11) || Math.abs(m00) < 1e-8 || Math.abs(m11) < 1e-8) {
     return mat4persp((70 * Math.PI) / 180, 1, nearKm, farKm);
   }
-  const fovY = 2 * Math.atan(1 / Math.abs(m11));
-  const aspect = Math.abs(m11 / m00);
-  return mat4persp(fovY, aspect > 1e-4 ? aspect : 1, nearKm, farKm);
+  const offsetX = Number.isFinite(xrProjection[8]) ? xrProjection[8] : 0;
+  const offsetY = Number.isFinite(xrProjection[9]) ? xrProjection[9] : 0;
+
+  // Tangents of the frustum edges, in near-plane units (right/near, etc).
+  const right = (1 + offsetX) / m00;
+  const left = (offsetX - 1) / m00;
+  const top = (1 + offsetY) / m11;
+  const bottom = (offsetY - 1) / m11;
+
+  // A mirrored/degenerate frustum would invert the image; fall back instead.
+  if (!(right > left) || !(top > bottom)) {
+    const fovY = 2 * Math.atan(1 / Math.abs(m11));
+    const aspect = Math.abs(m11 / m00);
+    return mat4persp(fovY, aspect > 1e-4 ? aspect : 1, nearKm, farKm);
+  }
+
+  return mat4frustum(
+    left * nearKm,
+    right * nearKm,
+    bottom * nearKm,
+    top * nearKm,
+    nearKm,
+    farKm,
+  );
 }
 
 export interface XrEyePoseInput {

--- a/src/xr/XrSessionManager.ts
+++ b/src/xr/XrSessionManager.ts
@@ -27,7 +27,7 @@ export class XrSessionManager {
   private hiddenEls: { el: HTMLElement; prev: string }[] = [];
   private onPhaseChange: ((phase: XrSessionPhase) => void) | null = null;
   private readonly onSessionEnd = (): void => {
-    void this.handleSessionEnded();
+    this.handleSessionEnded();
   };
 
   constructor(private readonly rt: AppRuntime) {}
@@ -123,7 +123,7 @@ export class XrSessionManager {
     try {
       await this.session.end();
     } catch {
-      await this.handleSessionEnded();
+      this.handleSessionEnded();
     }
   }
 
@@ -141,7 +141,7 @@ export class XrSessionManager {
     });
   }
 
-  private async handleSessionEnded(): Promise<void> {
+  private handleSessionEnded(): void {
     if (this.phase === 'idle') return;
     const session = this.session;
     if (session) {

--- a/src/xr/XrSupport.test.ts
+++ b/src/xr/XrSupport.test.ts
@@ -19,7 +19,7 @@ describe('XrSupport', () => {
   it('isImmersiveVrSupported reads isSessionSupported', async () => {
     vi.stubGlobal('navigator', {
       xr: {
-        isSessionSupported: vi.fn(async (mode: string) => mode === 'immersive-vr'),
+        isSessionSupported: vi.fn((mode: string) => Promise.resolve(mode === 'immersive-vr')),
         requestSession: vi.fn(),
       },
     });

--- a/src/xr/webxr-types.d.ts
+++ b/src/xr/webxr-types.d.ts
@@ -31,7 +31,7 @@ interface XRFrame {
   ): { transform: XRRigidTransform } | null;
 }
 
-interface XRSpace {}
+type XRSpace = object;
 
 interface XRReferenceSpace extends XRSpace {
   getOffsetReferenceSpace(originOffset: XRRigidTransform): XRReferenceSpace;


### PR DESCRIPTION
## Context

The staged WebXR work is already implemented and merged on `main`:

- **Stage 1** — `ViewDescriptor` decouples view/projection from the swapchain (`XrPoseBridge.viewDescriptorForXrEye`)
- **Stage 2** — `XrSessionManager` (session lifecycle, `local-floor`→`local` fallback, chrome hiding, quality preset via `XrQuality`, mono-loop restore), `XrFrameLoop` (per-eye draw into `XRWebGLLayer`), `XrAnchors` (720 km Horizon / GEO overview / ground station, smoothstep-blended snaps, no smooth locomotion), capability-gated Enter VR button in `App.initXrUi`
- **Stage 3** — partial by design: controller trigger cycles anchors; ray picking is explicitly deferred to the picking issue

Auditing that against the acceptance criteria, I found one real defect in the render path.

## The bug

`projectionFromXrFov` rebuilds each eye's projection with orbital near/far. That part is necessary and correct — WebXR's default 0.1/1000 m depth range would clip an Earth-scale scene entirely. But it rebuilt via `mat4persp`, keeping only the FOV diagonal and discarding the frustum's off-axis offsets:

```ts
const fovY = 2 * Math.atan(1 / Math.abs(m11));
const aspect = Math.abs(m11 / m00);
return mat4persp(fovY, aspect > 1e-4 ? aspect : 1, nearKm, farKm);
```

Headset eye frusta are **off-axis** — the lens axis sits away from the viewport centre, so `left != -right`. Symmetrising shifts each eye's image toward its own centre, in *opposite directions* for the two eyes. That corrupts binocular disparity and misaligns the stereo pair — the kind of error that reads as depth being subtly wrong and is a known discomfort trigger, which cuts against the comfort goals the anchor design is built around. For a representative HMD frustum the shift is ≈0.11 in NDC, roughly **5% of viewport width per eye**.

The existing test only fed a *symmetric* `mat4persp` input, so the asymmetry loss was invisible to it. The source comment ("Asymmetric FOV is approximated") acknowledged the gap.

## The fix

Recover the four frustum tangents from the XR matrix and re-emit them against the orbital depth range:

- **`src/utils/math.ts`** — new `mat4frustum(left, right, bottom, top, near, far)`, the off-axis generalisation of `mat4persp` in the same WebGPU-style z∈[0,1] convention. `mat4persp` is untouched.
- **`src/xr/XrPoseBridge.ts`** — extract `r/n, l/n, t/n, b/n` from `m00, m11, m[8], m[9]` and rebuild. Those four entries are **identical** under both the GL z∈[-1,1] and WebGPU z∈[0,1] conventions — only the depth row differs — so extraction is convention-independent whichever form the runtime emits. Degenerate matrices (non-finite, near-zero) and mirrored bounds still fall back to the symmetric path.

## Tests

Added to `XrPoseBridge.test.ts`, using a realistic off-axis eye frustum built in GL convention (what WebXR runtimes actually emit):

- **The property that matters:** view-space rays map to the same NDC x/y as the headset's own matrix, sampled across the frustum out to GEO distance
- Off-axis offsets survive rather than being zeroed
- Depth is re-targeted so a GEO-distance satellite sits inside the frustum instead of clipping
- Degenerate, NaN, and mirrored inputs stay finite and non-inverted

**Mutation-checked:** both key assertions fail against the previous symmetric implementation.

Also cleared 5 pre-existing lint errors in `src/xr` (unnecessary non-null assertions, async-without-await, empty interface) so the module passes `--max-warnings=0`.

## Verification

- `vitest run` — 37 files, 186 tests pass (14 in `src/xr`, up from 10)
- `tsc --noEmit` — clean
- `eslint src/xr src/utils/math.ts --max-warnings=0` — clean
- `vite build` — succeeds

**Non-XR experience is unaffected:** the changed function is reachable only from `XrFrameLoop`, and `mat4frustum` is a pure addition.

## Not verified here

I could not test on a real headset or emulator — this environment has no WebXR runtime and only software rendering (per `AGENTS.md`). The correctness argument is the NDC-equivalence property above, which is exact and unit-tested; **on-device confirmation of the end-to-end "enter VR and look around" criterion is still outstanding.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01YWfxNTrqEZdC3V2sAAkuD1)_