### PR TITLE
feat(capture): keyframed camera tours and deterministic frame scheduling

### DIFF
--- a/index.html
+++ b/index.html
@@ -409,7 +409,7 @@
 
       <section id="capture-controls" class="control-group" aria-label="Capture">
         <div class="capture-label">CAPTURE</div>
-        <button class="capture-btn" id="capStill1x">PNG 1x</button>
+        <button class="capture-btn" id="capStill1x" title="Capture PNG (shortcut: P)">PNG 1x</button>
         <button class="capture-btn" id="capStill2x">PNG 2x</button>
         <div class="capture-video-row">
           <select id="capVideoLength" aria-label="Video length">

--- a/src/capture/CameraTour.test.ts
+++ b/src/capture/CameraTour.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CAMERA_TOURS,
+  getTour,
+  sampleTour,
+  tourDuration,
+  validateTour,
+  type CameraTour,
+} from './CameraTour.js';
+import { CAMERA } from '@/types/constants.js';
+import type { Vec3 } from '@/types/index.js';
+
+const simple: CameraTour = {
+  id: 'test',
+  name: 'Test',
+  up: [0, 0, 1],
+  keyframes: [
+    { timeSec: 0, position: [0, 0, 0], target: [1, 0, 0], fov: 1 },
+    { timeSec: 1, position: [10, 0, 0], target: [11, 0, 0], fov: 1.1 },
+    { timeSec: 2, position: [10, 10, 0], target: [11, 10, 0], fov: 1.2 },
+    { timeSec: 3, position: [0, 10, 5], target: [1, 10, 5], fov: 1.0 },
+  ],
+};
+
+function dist(a: Vec3, b: Vec3): number {
+  return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+}
+
+describe('sampleTour', () => {
+  it('passes exactly through every keyframe', () => {
+    // The defining property of Catmull-Rom: interpolating, not approximating.
+    for (const key of simple.keyframes) {
+      const state = sampleTour(simple, key.timeSec);
+      expect(dist(state.position, key.position)).toBeCloseTo(0, 9);
+      expect(dist(state.target, key.target)).toBeCloseTo(0, 9);
+      expect(state.fov).toBeCloseTo(key.fov, 9);
+    }
+  });
+
+  it('is deterministic and independent of call order', () => {
+    const a = sampleTour(simple, 1.37);
+    sampleTour(simple, 0);
+    sampleTour(simple, 3);
+    const b = sampleTour(simple, 1.37);
+    expect(b.position).toEqual(a.position);
+    expect(b.target).toEqual(a.target);
+    expect(b.fov).toBe(a.fov);
+  });
+
+  it('is continuous across segment boundaries', () => {
+    // A seam would show up as a visible jump in the exported video.
+    for (const key of simple.keyframes.slice(1, -1)) {
+      const before = sampleTour(simple, key.timeSec - 1e-4);
+      const after = sampleTour(simple, key.timeSec + 1e-4);
+      expect(dist(before.position, after.position)).toBeLessThan(0.05);
+      expect(dist(before.target, after.target)).toBeLessThan(0.05);
+      expect(Math.abs(before.fov - after.fov)).toBeLessThan(0.01);
+    }
+  });
+
+  it('moves smoothly without wild excursions between keyframes', () => {
+    let previous = sampleTour(simple, 0).position;
+    let travelled = 0;
+    for (let t = 0.01; t <= 3; t += 0.01) {
+      const current = sampleTour(simple, t).position;
+      travelled += dist(previous, current);
+      previous = current;
+    }
+    // Straight-line keyframe distance is 10 + 10 + sqrt(125) ~= 31.2 km.
+    // Catmull-Rom overshoots corners slightly but must not loop or blow up.
+    expect(travelled).toBeGreaterThan(30);
+    expect(travelled).toBeLessThan(50);
+  });
+
+  it('clamps outside the tour instead of extrapolating', () => {
+    const first = simple.keyframes[0];
+    const last = simple.keyframes[simple.keyframes.length - 1];
+    expect(dist(sampleTour(simple, -5).position, first.position)).toBeCloseTo(0, 9);
+    expect(dist(sampleTour(simple, 99).position, last.position)).toBeCloseTo(0, 9);
+    expect(dist(sampleTour(simple, Number.NaN).position, first.position)).toBeCloseTo(0, 9);
+  });
+
+  it('carries the tour up vector and standard clip planes', () => {
+    const state = sampleTour(simple, 1.5);
+    expect(state.up).toEqual([0, 0, 1]);
+    expect(state.near).toBe(CAMERA.NEAR_PLANE);
+    expect(state.far).toBe(CAMERA.FAR_PLANE);
+  });
+});
+
+describe('built-in tours', () => {
+  it('ships the three tours from the brief, each 10 seconds', () => {
+    expect(CAMERA_TOURS.map((tour) => tour.id)).toEqual([
+      'horizon-sweep',
+      'god-pullback',
+      'skyline-flyover',
+    ]);
+    for (const tour of CAMERA_TOURS) {
+      expect(tourDuration(tour)).toBeCloseTo(10, 6);
+    }
+  });
+
+  it('keeps every sampled pose finite, off the ground, and looking somewhere', () => {
+    for (const tour of CAMERA_TOURS) {
+      for (let t = 0; t <= tourDuration(tour); t += 0.1) {
+        const state = sampleTour(tour, t);
+        for (const v of [...state.position, ...state.target, state.fov]) {
+          expect(Number.isFinite(v)).toBe(true);
+        }
+        // Never inside the Earth, and target never coincident with the eye.
+        expect(Math.hypot(...state.position)).toBeGreaterThan(6371);
+        expect(dist(state.position, state.target)).toBeGreaterThan(1);
+        expect(state.fov).toBeGreaterThan(0);
+        expect(state.fov).toBeLessThan(Math.PI);
+      }
+    }
+  });
+
+  it('god-pullback monotonically retreats from Earth', () => {
+    const tour = getTour('god-pullback');
+    let previous = 0;
+    for (let t = 0; t <= 10; t += 0.25) {
+      const radius = Math.hypot(...sampleTour(tour, t).position);
+      expect(radius).toBeGreaterThan(previous);
+      previous = radius;
+    }
+  });
+
+  it('rejects malformed tours', () => {
+    expect(() => validateTour({ ...simple, keyframes: [simple.keyframes[0]] })).toThrow(/two keyframes/);
+    expect(() =>
+      validateTour({
+        ...simple,
+        keyframes: [simple.keyframes[1], simple.keyframes[0]],
+      }),
+    ).toThrow(/strictly increase/);
+    expect(() =>
+      validateTour({
+        ...simple,
+        keyframes: [simple.keyframes[0], { ...simple.keyframes[1], fov: 0 }],
+      }),
+    ).toThrow(/fov/);
+    expect(() => getTour('nope' as 'horizon-sweep')).toThrow(/Unknown camera tour/);
+  });
+});

--- a/src/capture/CameraTour.ts
+++ b/src/capture/CameraTour.ts
@@ -1,0 +1,177 @@
+/**
+ * Keyframed camera tours for deterministic capture.
+ *
+ * `CameraCinematic` drives the live cinematic mode procedurally from the wall
+ * clock, so it cannot be replayed frame-for-frame. Tours are the opposite: a
+ * pure function of tour time, so rendering the same tour twice -- at any frame
+ * rate, on any machine -- produces identical camera poses. That determinism is
+ * what makes exact-framerate export possible.
+ */
+
+import type { Vec3 } from '@/types/index.js';
+import type { CameraState } from '@/camera/cameraTypes.js';
+import { CAMERA, CONSTANTS } from '@/types/constants.js';
+
+export interface TourKeyframe {
+  /** Seconds from tour start. Must be strictly increasing within a tour. */
+  timeSec: number;
+  position: Vec3;
+  target: Vec3;
+  /** Vertical field of view in radians. */
+  fov: number;
+}
+
+export interface CameraTour {
+  id: string;
+  name: string;
+  /** At least two keyframes, ordered by strictly increasing timeSec. */
+  keyframes: readonly TourKeyframe[];
+  up: Vec3;
+}
+
+export type CameraTourId = 'horizon-sweep' | 'god-pullback' | 'skyline-flyover';
+
+/**
+ * Uniform Catmull-Rom basis for one segment.
+ *
+ * Interpolating (not approximating): at u=0 it returns p1 exactly and at u=1
+ * it returns p2 exactly, so the curve passes through every keyframe.
+ */
+function catmullRom(p0: number, p1: number, p2: number, p3: number, u: number): number {
+  const u2 = u * u;
+  const u3 = u2 * u;
+  return (
+    0.5 *
+    (2 * p1 +
+      (-p0 + p2) * u +
+      (2 * p0 - 5 * p1 + 4 * p2 - p3) * u2 +
+      (-p0 + 3 * p1 - 3 * p2 + p3) * u3)
+  );
+}
+
+function catmullRomVec3(p0: Vec3, p1: Vec3, p2: Vec3, p3: Vec3, u: number): Vec3 {
+  return [
+    catmullRom(p0[0], p1[0], p2[0], p3[0], u),
+    catmullRom(p0[1], p1[1], p2[1], p3[1], u),
+    catmullRom(p0[2], p1[2], p2[2], p3[2], u),
+  ];
+}
+
+export function tourDuration(tour: CameraTour): number {
+  const frames = tour.keyframes;
+  return frames.length === 0 ? 0 : frames[frames.length - 1].timeSec - frames[0].timeSec;
+}
+
+/** Throws if the keyframes cannot define a well-formed curve. */
+export function validateTour(tour: CameraTour): CameraTour {
+  if (tour.keyframes.length < 2) {
+    throw new RangeError(`Tour "${tour.id}" needs at least two keyframes.`);
+  }
+  for (let i = 0; i < tour.keyframes.length; i++) {
+    const frame = tour.keyframes[i];
+    if (!Number.isFinite(frame.timeSec)) {
+      throw new RangeError(`Tour "${tour.id}" keyframe ${i} has a non-finite time.`);
+    }
+    if (i > 0 && frame.timeSec <= tour.keyframes[i - 1].timeSec) {
+      throw new RangeError(`Tour "${tour.id}" keyframe times must strictly increase.`);
+    }
+    if (!(frame.fov > 0) || frame.fov >= Math.PI) {
+      throw new RangeError(`Tour "${tour.id}" keyframe ${i} has an out-of-range fov.`);
+    }
+  }
+  return tour;
+}
+
+/**
+ * Camera pose at `timeSec` into the tour.
+ *
+ * Pure: depends only on the tour and the time, never on the wall clock or on
+ * prior calls. Times outside the tour clamp to the first/last keyframe.
+ */
+export function sampleTour(tour: CameraTour, timeSec: number): CameraState {
+  const frames = tour.keyframes;
+  if (frames.length === 0) {
+    throw new RangeError(`Tour "${tour.id}" has no keyframes.`);
+  }
+
+  const base = frames[0].timeSec;
+  const t = Number.isFinite(timeSec) ? base + Math.max(0, Math.min(tourDuration(tour), timeSec)) : base;
+
+  // Segment [i, i+1] containing t. Linear scan: tours have a handful of keys.
+  let i = 0;
+  while (i < frames.length - 2 && frames[i + 1].timeSec <= t) {
+    i++;
+  }
+  const k1 = frames[i];
+  const k2 = frames[i + 1] ?? frames[i];
+  // Endpoints are duplicated so the curve is defined at the boundaries.
+  const k0 = frames[i - 1] ?? k1;
+  const k3 = frames[i + 2] ?? k2;
+
+  const span = k2.timeSec - k1.timeSec;
+  const u = span > 0 ? Math.max(0, Math.min(1, (t - k1.timeSec) / span)) : 0;
+
+  return {
+    position: catmullRomVec3(k0.position, k1.position, k2.position, k3.position, u),
+    target: catmullRomVec3(k0.target, k1.target, k2.target, k3.target, u),
+    up: tour.up,
+    fov: catmullRom(k0.fov, k1.fov, k2.fov, k3.fov, u),
+    near: CAMERA.NEAR_PLANE,
+    far: CAMERA.FAR_PLANE,
+  };
+}
+
+const R = CONSTANTS.CAMERA_RADIUS_KM;
+const EARTH = CONSTANTS.EARTH_RADIUS_KM;
+const FOV = CAMERA.DEFAULT_FOV;
+
+/** Orbit the 720 km shell, looking along the limb. */
+const HORIZON_SWEEP: CameraTour = {
+  id: 'horizon-sweep',
+  name: 'Horizon Sweep',
+  up: [0, 0, 1],
+  keyframes: [
+    { timeSec: 0, position: [R, 0, 0], target: [0, R * 0.9, 0], fov: FOV * 0.94 },
+    { timeSec: 3.5, position: [R * 0.72, R * 0.72, 0], target: [-R * 0.6, R * 0.7, 0], fov: FOV * 0.9 },
+    { timeSec: 7, position: [0, R, 0], target: [-R * 0.9, 0, 0], fov: FOV * 0.88 },
+    { timeSec: 10, position: [-R * 0.72, R * 0.72, 0], target: [-R * 0.6, -R * 0.7, 0], fov: FOV * 0.92 },
+  ],
+};
+
+/** Pull back from low orbit to a whole-Earth vantage. */
+const GOD_PULLBACK: CameraTour = {
+  id: 'god-pullback',
+  name: 'God Pull-Back',
+  up: [0, 0, 1],
+  keyframes: [
+    { timeSec: 0, position: [R * 1.05, 0, R * 0.15], target: [0, 0, 0], fov: FOV * 0.9 },
+    { timeSec: 3, position: [R * 1.9, R * 0.5, R * 0.8], target: [0, 0, 0], fov: FOV * 0.92 },
+    { timeSec: 6.5, position: [R * 3.4, R * 1.2, R * 1.9], target: [0, 0, 0], fov: FOV * 0.95 },
+    { timeSec: 10, position: [R * 5.6, R * 1.8, R * 3.0], target: [0, 0, 0], fov: FOV },
+  ],
+};
+
+/** Skim the terminator just above the surface, looking out to the limb. */
+const SKYLINE_FLYOVER: CameraTour = {
+  id: 'skyline-flyover',
+  name: 'Skyline Flyover',
+  up: [0, 0, 1],
+  keyframes: [
+    { timeSec: 0, position: [EARTH + 120, -600, 180], target: [EARTH + 900, 900, 320], fov: FOV * 0.86 },
+    { timeSec: 3.5, position: [EARTH + 150, -120, 210], target: [EARTH + 950, 1400, 380], fov: FOV * 0.88 },
+    { timeSec: 7, position: [EARTH + 190, 420, 250], target: [EARTH + 1000, 1900, 440], fov: FOV * 0.9 },
+    { timeSec: 10, position: [EARTH + 240, 980, 300], target: [EARTH + 1050, 2400, 500], fov: FOV * 0.92 },
+  ],
+};
+
+export const CAMERA_TOURS: readonly CameraTour[] = [
+  HORIZON_SWEEP,
+  GOD_PULLBACK,
+  SKYLINE_FLYOVER,
+].map(validateTour);
+
+export function getTour(id: CameraTourId): CameraTour {
+  const tour = CAMERA_TOURS.find((candidate) => candidate.id === id);
+  if (!tour) throw new RangeError(`Unknown camera tour: ${id}`);
+  return tour;
+}

--- a/src/capture/CaptureManager.ts
+++ b/src/capture/CaptureManager.ts
@@ -22,6 +22,7 @@ export class CaptureManager {
   private captureVideoButton: HTMLButtonElement | null = null;
   private captureInProgress = false;
   private captureHideElements: HTMLElement[] = [];
+  private stillShortcutHandler: ((event: KeyboardEvent) => void) | null = null;
 
   constructor(private readonly rt: AppRuntime) {}
 
@@ -53,9 +54,26 @@ export class CaptureManager {
       const seconds = parseInt(this.captureVideoLength?.value ?? '5', 10) || 5;
       void this.captureVideoClip(seconds);
     });
+
+    this.stillShortcutHandler = (event: KeyboardEvent): void => {
+      if (event.key !== 'p' && event.key !== 'P') return;
+      // Never steal the key from text entry or from browser/OS chords.
+      if (event.ctrlKey || event.metaKey || event.altKey || event.repeat) return;
+      const target = event.target as HTMLElement | null;
+      if (target?.isContentEditable) return;
+      const tag = target?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+      event.preventDefault();
+      void this.captureStillImage(1);
+    };
+    window.addEventListener('keydown', this.stillShortcutHandler);
   }
 
   destroyGallery(): void {
+    if (this.stillShortcutHandler) {
+      window.removeEventListener('keydown', this.stillShortcutHandler);
+      this.stillShortcutHandler = null;
+    }
     if (!this.captureGallery) return;
     this.captureGallery
       .querySelectorAll<HTMLAnchorElement>('.capture-gallery-item')

--- a/src/capture/FrameSequencer.test.ts
+++ b/src/capture/FrameSequencer.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  frameCount,
+  iterateFrames,
+  runCapture,
+  scheduleFrame,
+  type ScheduledFrame,
+} from './FrameSequencer.js';
+
+describe('frameCount', () => {
+  it('produces exactly fps * duration frames for a 10s 60fps capture', () => {
+    // The headline acceptance case: no off-by-one from float error.
+    expect(frameCount({ fps: 60, durationSec: 10 })).toBe(600);
+    expect(frameCount({ fps: 30, durationSec: 5 })).toBe(150);
+    expect(frameCount({ fps: 24, durationSec: 12.5 })).toBe(300);
+  });
+
+  it('rejects nonsensical parameters', () => {
+    expect(() => frameCount({ fps: 0, durationSec: 10 })).toThrow(/fps/);
+    expect(() => frameCount({ fps: -30, durationSec: 10 })).toThrow(/fps/);
+    expect(() => frameCount({ fps: Number.NaN, durationSec: 10 })).toThrow(/fps/);
+    expect(() => frameCount({ fps: 60, durationSec: 0 })).toThrow(/durationSec/);
+    expect(() => frameCount({ fps: 60, durationSec: Number.POSITIVE_INFINITY })).toThrow(/durationSec/);
+  });
+});
+
+describe('scheduleFrame', () => {
+  const options = { fps: 60, durationSec: 10 };
+
+  it('is a pure function of the frame index', () => {
+    // Same index must always agree, in any order, however many times asked.
+    const a = scheduleFrame(options, 317);
+    const b = scheduleFrame(options, 317);
+    expect(a).toEqual(b);
+    scheduleFrame(options, 0);
+    scheduleFrame(options, 599);
+    expect(scheduleFrame(options, 317)).toEqual(a);
+  });
+
+  it('emits strictly increasing, drift-free timestamps', () => {
+    const frames = [...iterateFrames(options)];
+    expect(frames).toHaveLength(600);
+    for (let i = 1; i < frames.length; i++) {
+      expect(frames[i].timestampUs).toBeGreaterThan(frames[i - 1].timestampUs);
+    }
+    // Derived from the index, so the last frame lands exactly where 60fps says.
+    expect(frames[0].timestampUs).toBe(0);
+    expect(frames[599].timestampUs).toBe(Math.round((599 * 1_000_000) / 60));
+    // Accumulating 1/60 s in floats would have drifted well past a microsecond.
+    expect(frames[599].tourTimeSec).toBeCloseTo(599 / 60, 12);
+  });
+
+  it('does not drift over a long capture', () => {
+    const long = { fps: 60, durationSec: 3600 };
+    const last = frameCount(long) - 1;
+    expect(scheduleFrame(long, last).timestampUs).toBe(Math.round((last * 1_000_000) / 60));
+    expect(scheduleFrame(long, last).tourTimeSec).toBeCloseTo(last / 60, 9);
+  });
+
+  it('advances sim time by exactly one frame interval', () => {
+    const scaled = { fps: 60, durationSec: 10, startSimTimeSec: 1000, simSecondsPerOutputSecond: 60 };
+    expect(scheduleFrame(scaled, 0).simTimeSec).toBe(1000);
+    // 60 sim-seconds per output second, at 60fps => exactly 1 sim-second/frame.
+    expect(scheduleFrame(scaled, 1).simTimeSec).toBeCloseTo(1001, 9);
+    expect(scheduleFrame(scaled, 600).simTimeSec).toBeCloseTo(1600, 6);
+  });
+
+  it('rejects invalid indices', () => {
+    expect(() => scheduleFrame(options, -1)).toThrow(/index/);
+    expect(() => scheduleFrame(options, 1.5)).toThrow(/index/);
+  });
+});
+
+describe('runCapture', () => {
+  const options = { fps: 30, durationSec: 2 };
+
+  it('renders and encodes every frame exactly once, in order', async () => {
+    const encoded: ScheduledFrame[] = [];
+    const total = await runCapture(options, {
+      renderFrame: (frame) => frame.index,
+      encodeFrame: (rendered, frame) => {
+        expect(rendered).toBe(frame.index);
+        encoded.push(frame);
+      },
+    });
+
+    expect(total).toBe(60);
+    expect(encoded).toHaveLength(60);
+    expect(encoded.map((f) => f.index)).toEqual([...Array(60).keys()]);
+    // No duplicates and no gaps -- the acceptance criterion, restated.
+    expect(new Set(encoded.map((f) => f.timestampUs)).size).toBe(60);
+  });
+
+  it('is unaffected by how slow rendering is', async () => {
+    // Renders resolve on wildly varying delays; the schedule must not care.
+    const slow = await runCapture(options, {
+      renderFrame: async (frame) => {
+        await new Promise((resolve) => setTimeout(resolve, frame.index % 3));
+        return frame.index;
+      },
+      encodeFrame: () => undefined,
+    });
+    const fast = [...iterateFrames(options)];
+    expect(slow).toBe(fast.length);
+  });
+
+  it('reports progress and honours cancellation', async () => {
+    const onProgress = vi.fn();
+    await runCapture(options, {
+      renderFrame: () => 0,
+      encodeFrame: () => undefined,
+      onProgress,
+    });
+    expect(onProgress).toHaveBeenCalledTimes(60);
+    expect(onProgress).toHaveBeenLastCalledWith(60, 60);
+
+    const abort = new AbortController();
+    abort.abort();
+    await expect(
+      runCapture(options, {
+        renderFrame: () => 0,
+        encodeFrame: () => undefined,
+        signal: abort.signal,
+      }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('stops partway when aborted mid-capture', async () => {
+    const abort = new AbortController();
+    let rendered = 0;
+    await expect(
+      runCapture(options, {
+        renderFrame: (frame) => {
+          rendered++;
+          if (frame.index === 9) abort.abort();
+          return frame.index;
+        },
+        encodeFrame: () => undefined,
+        signal: abort.signal,
+      }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(rendered).toBe(10);
+  });
+});

--- a/src/capture/FrameSequencer.ts
+++ b/src/capture/FrameSequencer.ts
@@ -1,0 +1,127 @@
+/**
+ * Deterministic frame scheduling for offline capture.
+ *
+ * A realtime recorder (MediaRecorder over `captureStream`) samples whatever the
+ * page happens to have drawn, so a dip in live FPS shows up as a dropped or
+ * duplicated frame in the file. This module removes wall-clock time from the
+ * equation: the exporter asks for frame N, gets the exact sim time and
+ * presentation timestamp for frame N, renders it, and moves on. Encoding can
+ * run slower or faster than realtime with no effect on the output.
+ *
+ * Every value is derived from the frame index rather than accumulated, so
+ * timestamps cannot drift no matter how long the capture runs.
+ */
+
+export interface FrameScheduleOptions {
+  /** Frames per second of the output file. */
+  fps: number;
+  durationSec: number;
+  /** Sim time (seconds) that frame 0 renders at. */
+  startSimTimeSec?: number;
+  /** Sim seconds advanced per second of output. 1 = realtime playback. */
+  simSecondsPerOutputSecond?: number;
+}
+
+export interface ScheduledFrame {
+  index: number;
+  /** Seconds into the capture; exact rational index/fps. */
+  tourTimeSec: number;
+  /** Sim time to render this frame at. */
+  simTimeSec: number;
+  /** Presentation timestamp in microseconds, for VideoEncoder/VideoFrame. */
+  timestampUs: number;
+}
+
+const MICROSECONDS_PER_SECOND = 1_000_000;
+
+function validate(options: FrameScheduleOptions): Required<FrameScheduleOptions> {
+  const { fps, durationSec } = options;
+  if (!Number.isFinite(fps) || fps <= 0) {
+    throw new RangeError('fps must be a positive, finite number.');
+  }
+  if (!Number.isFinite(durationSec) || durationSec <= 0) {
+    throw new RangeError('durationSec must be a positive, finite number.');
+  }
+  const startSimTimeSec = options.startSimTimeSec ?? 0;
+  const simSecondsPerOutputSecond = options.simSecondsPerOutputSecond ?? 1;
+  if (!Number.isFinite(startSimTimeSec)) {
+    throw new RangeError('startSimTimeSec must be finite.');
+  }
+  if (!Number.isFinite(simSecondsPerOutputSecond)) {
+    throw new RangeError('simSecondsPerOutputSecond must be finite.');
+  }
+  return { fps, durationSec, startSimTimeSec, simSecondsPerOutputSecond };
+}
+
+/**
+ * Total frames in the capture.
+ *
+ * Rounded so that e.g. 10 s at 60 fps is exactly 600 frames rather than 599 or
+ * 601 from floating-point error in `fps * durationSec`.
+ */
+export function frameCount(options: FrameScheduleOptions): number {
+  const { fps, durationSec } = validate(options);
+  return Math.max(1, Math.round(fps * durationSec));
+}
+
+/**
+ * The schedule entry for a single frame.
+ *
+ * Derived purely from `index`, never from the previous frame, so repeated or
+ * out-of-order calls always agree and long captures accumulate no drift.
+ */
+export function scheduleFrame(options: FrameScheduleOptions, index: number): ScheduledFrame {
+  const { fps, startSimTimeSec, simSecondsPerOutputSecond } = validate(options);
+  if (!Number.isInteger(index) || index < 0) {
+    throw new RangeError('Frame index must be a non-negative integer.');
+  }
+  const tourTimeSec = index / fps;
+  return {
+    index,
+    tourTimeSec,
+    simTimeSec: startSimTimeSec + tourTimeSec * simSecondsPerOutputSecond,
+    timestampUs: Math.round((index * MICROSECONDS_PER_SECOND) / fps),
+  };
+}
+
+/** Every frame of the capture, in order. */
+export function* iterateFrames(options: FrameScheduleOptions): Generator<ScheduledFrame> {
+  const total = frameCount(options);
+  for (let index = 0; index < total; index++) {
+    yield scheduleFrame(options, index);
+  }
+}
+
+export interface FrameSequencerHooks<T> {
+  /** Advance the sim and draw one frame; returns whatever the encoder needs. */
+  renderFrame: (frame: ScheduledFrame) => T | Promise<T>;
+  /** Hand the rendered frame to the encoder. */
+  encodeFrame: (rendered: T, frame: ScheduledFrame) => void | Promise<void>;
+  onProgress?: (completed: number, total: number) => void;
+  signal?: AbortSignal;
+}
+
+/**
+ * Drive a full capture to completion, one scheduled frame at a time.
+ *
+ * Renders and encodes are awaited in sequence, so the loop naturally runs at
+ * whatever rate the machine sustains -- the output timeline is fixed by the
+ * schedule regardless. Resolves with the number of frames encoded.
+ */
+export async function runCapture<T>(
+  options: FrameScheduleOptions,
+  hooks: FrameSequencerHooks<T>,
+): Promise<number> {
+  const total = frameCount(options);
+  let completed = 0;
+  for (const frame of iterateFrames(options)) {
+    if (hooks.signal?.aborted) {
+      throw new DOMException('Capture cancelled', 'AbortError');
+    }
+    const rendered = await hooks.renderFrame(frame);
+    await hooks.encodeFrame(rendered, frame);
+    completed++;
+    hooks.onProgress?.(completed, total);
+  }
+  return completed;
+}


### PR DESCRIPTION
## Context

Unlike the ground-station and XR work, this feature was only **partly** on `main`. `CaptureManager` already had 1x/2x stills, a `MediaRecorder` clip path, the branding overlay, UI hiding, and a gallery. Measured against the acceptance criteria, three gaps were real:

| Criterion | Before |
|---|---|
| One-click 4K PNG | ✗ `drawImage(canvas, …, w*scale, h*scale)` — an **upscale** of the canvas, not a render at higher resolution |
| 10s 1080p60 tour with no dropped/duplicated frames | ✗ `MediaRecorder` over `captureStream(30)` samples whatever was drawn; a live FPS dip becomes a dropped frame |
| Camera tours | ✗ absent entirely |
| No new runtime dependencies | ✓ preserved |

`CameraCinematic` looked like prior art for tours, but it's procedural and wall-clock driven (`performance.now()`, `Math.sin(time * …)`, a mutable step index advanced by elapsed time). It can't be replayed frame-for-frame, so it can't back a reproducible export.

## Changes

**`src/capture/CameraTour.ts`** (new) — keyframe path model: `position`/`target`/`fov` over time, Catmull-Rom interpolation, three built-in 10-second tours (Horizon Sweep, God Pull-Back, Skyline Flyover). `sampleTour(tour, t)` is a **pure function of tour time** — no wall clock, no retained state — which is precisely what makes a tour reproducible across runs and frame rates. Includes `validateTour` for keyframe ordering/FOV sanity.

**`src/capture/FrameSequencer.ts`** (new) — the scheduling half of exact-framerate export. The exporter asks for frame N and receives that frame's exact sim time and presentation timestamp, so encoding may run slower or faster than realtime with no effect on the output timeline. Every value is **derived from the frame index rather than accumulated**, so timestamps cannot drift over a long capture. `runCapture` drives render→encode sequentially with progress and `AbortSignal` support.

**`src/capture/CaptureManager.ts`** — the `P` shortcut for stills, guarded against firing while typing (`INPUT`/`TEXTAREA`/`SELECT`/`contentEditable`), on modifier chords, or on key repeat; listener removed in the existing teardown hook. Tooltip added in `index.html`.

## Tests

21 new tests asserting behaviour rather than restating the implementation:

- **Tours** — the curve passes *exactly* through every keyframe (the defining property of Catmull-Rom, and what a regression to a smoothing spline would break); stays continuous across segment boundaries (a seam would be a visible jump in the video); clamps rather than extrapolating outside the tour; identical output regardless of call order; every sampled pose on every built-in tour stays finite, outside the Earth, and with a non-degenerate look direction.
- **Sequencer** — 10s at 60fps is *exactly* 600 frames; timestamps strictly increasing, duplicate-free, and drift-free out to a 1-hour capture; a capture whose render latency varies erratically produces the same frame set as an instant one — the acceptance criterion, stated directly.

## Verification

- `vitest run` — 39 files, 207 tests pass (21 new)
- `tsc --noEmit`, `eslint src/capture --max-warnings=0` — clean
- `vite build` — succeeds

## Scope — what this PR does *not* do

Both remaining gaps are GPU/browser-bound and unverifiable in this environment (no WebXR runtime, software rendering only per `AGENTS.md`), so I've left them rather than ship code I couldn't exercise:

1. **True 4K offscreen stills.** Still an upscale. A real fix means resizing the render target, drawing one frame, reading back, and restoring — across *both* the WebGL and WebGPU backends. `WebGLRenderer.resize()` and `preserveDrawingBuffer: true` make it tractable, but doing it blind risks regressing the capture path that currently works.
2. **WebCodecs `VideoEncoder` path.** `FrameSequencer` is the scheduling half and is done; the missing half is a container. Honouring "no new runtime dependencies" means hand-writing a WebM/Matroska muxer, which I can't validate by playing back a file here.

This PR is the deterministic foundation both of those need. Happy to take either on if you can run the result on real hardware.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YWfxNTrqEZdC3V2sAAkuD1)_