### PR TITLE
feat(core): closed-loop quality governor with AUTO as the default

### DIFF
--- a/index.html
+++ b/index.html
@@ -362,6 +362,15 @@
       <section id="quality-controls" class="control-group" aria-label="Rendering Quality">
         <div class="quality-label">QUALITY</div>
         <button
+          class="quality-btn active"
+          id="qauto"
+          data-quality="auto"
+          title="Adapt quality automatically to hold a smooth frame rate"
+          aria-label="Adapt quality automatically"
+        >
+          AUTO
+        </button>
+        <button
           class="quality-btn"
           id="qlow"
           data-quality="low"

--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -14,6 +14,7 @@ import type { QualityLevel } from '@/core/QualityPresets.js';
 import type { FocusManager, FocusSelection } from '@/focus.js';
 import type { CaptureManager } from '@/capture/CaptureManager.js';
 import type { A11yController } from '@/a11y/A11yController.js';
+import { PerformanceGovernor } from '@/core/PerformanceGovernor.js';
 import type { ChipCatalogId } from '@/data/ConstellationGroups.js';
 import type { TLEData } from '@/types/index.js';
 import type { AppRuntime } from '@/app/AppRuntime.js';
@@ -99,6 +100,7 @@ export class App implements AppRuntime {
   webglDebugOverlay = null as AppRuntime['webglDebugOverlay'];
   captureManager: CaptureManager | null = null;
   a11y: A11yController | null = null;
+  readonly governor = new PerformanceGovernor();
   groundStationPanel: GroundStationPanel | null = null;
   readonly groundStationGuides: GroundStationGuides;
   xrSession: XrSessionManager | null = null;

--- a/src/app/AppCallbackBinder.ts
+++ b/src/app/AppCallbackBinder.ts
@@ -3,6 +3,7 @@ import { saveImageTuning } from '@/core/ImageTuning.js';
 import { applyExposureSettings as applyExposureSettingsImpl } from '@/core/ExposureRuntime.js';
 import { CaptureManager } from '@/capture/CaptureManager.js';
 import { A11yController } from '@/a11y/A11yController.js';
+import { QUALITY_PRESETS } from '@/core/QualityPresets.js';
 import {
   setupGroundPresetButtons,
   setupTAAToggle,
@@ -185,9 +186,26 @@ export function setupCallbacks(rt: AppRuntime): void {
   rt.ui.setDemoAutoEnabled(rt.simulation.demoAutoEnabled);
   rt.ui.setExposureControls(rt.exposureSettings);
 
+  // Closed-loop quality. Frame time comes from the profiler, which prefers GPU
+  // timestamp-query totals and falls back to rAF deltas, so this works on
+  // devices without the timestamp-query feature.
+  let lastGovernorSampleMs = performance.now();
+  rt.governor.subscribe((change) => {
+    rt.applyQualityPreset(change.to);
+    rt.ui.setQualityDisplay(change.to);
+    if (change.reason !== 'manual') {
+      rt.ui.showToast?.(`Performance mode: ${QUALITY_PRESETS[change.to].label.toLowerCase()}`);
+    }
+  });
+
   rt.profiler.onStatsUpdate((stats) => {
     rt.ui.updateStats(stats);
     rt.lastVisibleCount = stats.visibleSatellites;
+
+    const now = performance.now();
+    const deltaSec = (now - lastGovernorSampleMs) / 1000;
+    lastGovernorSampleMs = now;
+    rt.governor.sample(stats.frameTime, deltaSec);
   });
 
   setupPatternButtons(rt);
@@ -211,8 +229,13 @@ export function setupCallbacks(rt: AppRuntime): void {
   });
   rt.a11y.install();
 
+  // Picking a preset pins the governor; AUTO hands control back.
   rt.ui.onQualityChange((level) => {
+    rt.governor.setManual(level);
     rt.applyQualityPreset(level);
+  });
+  rt.ui.onAutoQualityChange(() => {
+    rt.governor.setAuto();
   });
 
   setupTAAToggle(rt);

--- a/src/app/AppRuntime.ts
+++ b/src/app/AppRuntime.ts
@@ -23,6 +23,7 @@ import type { WebGLDebugOverlay } from '@/webgl/WebGLDebug.js';
 import type { RendererBackend } from '@/webgl/rendererSelection.js';
 import type { CaptureManager } from '@/capture/CaptureManager.js';
 import type { A11yController } from '@/a11y/A11yController.js';
+import type { PerformanceGovernor } from '@/core/PerformanceGovernor.js';
 import type { SimulationState } from '@/app/SimulationState.js';
 import type { ViewModeState } from '@/app/ViewModeCoordinator.js';
 import type { FrameLoopState } from '@/app/FrameLoop.js';
@@ -70,6 +71,7 @@ export interface AppRuntime {
   webglDebugOverlay: WebGLDebugOverlay | null;
   captureManager: CaptureManager | null;
   a11y: A11yController | null;
+  governor: PerformanceGovernor;
   groundStationPanel: GroundStationPanel | null;
   groundStationGuides: GroundStationGuides;
   xrSession: XrSessionManager | null;

--- a/src/core/PerformanceGovernor.test.ts
+++ b/src/core/PerformanceGovernor.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  PerformanceGovernor,
+  QUALITY_LADDER,
+
+  type QualityChange,
+} from './PerformanceGovernor.js';
+import type { QualityLevel } from './QualityPresets.js';
+
+/** Frame time each quality level costs on a simulated device. */
+type DeviceProfile = Record<QualityLevel, number>;
+
+/** An iGPU: only the bottom of the ladder fits in budget. */
+const THROTTLED: DeviceProfile = { low: 9, balanced: 15.5, high: 28, cinematic: 42 };
+/** A 4090: everything is cheap. */
+const FAST: DeviceProfile = { low: 3, balanced: 4.5, high: 7, cinematic: 10 };
+/** Pathological: even the cheapest level misses budget. */
+const HOPELESS: DeviceProfile = { low: 30, balanced: 48, high: 70, cinematic: 96 };
+
+interface RunResult {
+  elapsedSec: number;
+  changes: QualityChange[];
+  /** Level at the end of each simulated second. */
+  timeline: QualityLevel[];
+}
+
+/**
+ * Drive the governor with a device's real frame times, feeding back the level
+ * it selects -- a closed loop, not a fixed trace.
+ */
+function run(
+  governor: PerformanceGovernor,
+  device: DeviceProfile,
+  seconds: number,
+  jitter = 0,
+): RunResult {
+  const changes: QualityChange[] = [];
+  governor.subscribe((change) => changes.push(change));
+
+  const timeline: QualityLevel[] = [];
+  let elapsed = 0;
+  let nextMark = 1;
+  // Deterministic pseudo-jitter, so a failure is always reproducible.
+  let seed = 12345;
+  const noise = (): number => {
+    seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+    return ((seed / 0x7fffffff) * 2 - 1) * jitter;
+  };
+
+  while (elapsed < seconds) {
+    const frameMs = device[governor.level] + noise();
+    const deltaSec = frameMs / 1000;
+    governor.sample(frameMs, deltaSec);
+    elapsed += deltaSec;
+    while (nextMark <= elapsed && timeline.length < seconds) {
+      timeline.push(governor.level);
+      nextMark++;
+    }
+  }
+  return { elapsedSec: elapsed, changes, timeline };
+}
+
+/** Seconds until the governor first reaches a level that holds the target. */
+function convergenceSec(
+  governor: PerformanceGovernor,
+  device: DeviceProfile,
+  targetFps: number,
+  limitSec: number,
+): number | null {
+  const budgetMs = 1000 / targetFps;
+  let elapsed = 0;
+  while (elapsed < limitSec) {
+    const frameMs = device[governor.level];
+    if (frameMs <= budgetMs) return elapsed;
+    const deltaSec = frameMs / 1000;
+    governor.sample(frameMs, deltaSec);
+    elapsed += deltaSec;
+  }
+  return null;
+}
+
+describe('PerformanceGovernor — acceptance criteria', () => {
+  it('converges to >= 50 FPS within 10 seconds on a throttled GPU', () => {
+    // Starts at cinematic (42ms ~= 24fps) and must find its way down unaided.
+    const governor = new PerformanceGovernor('cinematic');
+    const reachedAt = convergenceSec(governor, THROTTLED, 50, 10);
+
+    expect(reachedAt).not.toBeNull();
+    expect(reachedAt!).toBeLessThan(10);
+    // balanced is 15.5ms ~= 64fps, comfortably past the 50fps bar.
+    expect(governor.level).toBe('balanced');
+  });
+
+  it('does not oscillate once settled', () => {
+    const governor = new PerformanceGovernor('cinematic');
+    const { changes, timeline } = run(governor, THROTTLED, 120);
+
+    // Descent is monotonic: cinematic -> high -> balanced, then nothing.
+    expect(changes.map((c) => c.to)).toEqual(['high', 'balanced']);
+    expect(changes.every((c) => c.reason === 'downshift')).toBe(true);
+    // Two full minutes with no further movement.
+    expect(new Set(timeline.slice(10))).toEqual(new Set(['balanced']));
+  });
+
+  it('does not oscillate on a device sitting right at the boundary', () => {
+    // balanced lands inside the deadband (13 < 17.5 < 18) and high is just
+    // over: the classic flapping setup.
+    const boundary: DeviceProfile = { low: 8, balanced: 17.5, high: 18.4, cinematic: 25 };
+    const governor = new PerformanceGovernor('high');
+    const { changes } = run(governor, boundary, 300);
+
+    expect(governor.level).toBe('balanced');
+    // One decisive move, not a cycle.
+    expect(changes).toHaveLength(1);
+  });
+
+  it('survives noisy frame times without thrashing', () => {
+    const governor = new PerformanceGovernor('cinematic');
+    const { changes } = run(governor, THROTTLED, 180, 3.5);
+
+    expect(governor.level).toBe('balanced');
+    // Some extra probing is tolerable; a flapping loop is not.
+    expect(changes.length).toBeLessThanOrEqual(4);
+  });
+
+  it('manual selection fully disables the governor', () => {
+    const governor = new PerformanceGovernor('cinematic');
+    governor.setManual('cinematic');
+    const { changes } = run(governor, THROTTLED, 120);
+
+    // Pinned to a level this device cannot sustain, and left there.
+    expect(governor.level).toBe('cinematic');
+    expect(changes).toHaveLength(0);
+  });
+
+  it('resumes adapting when returned to auto', () => {
+    const governor = new PerformanceGovernor('cinematic');
+    governor.setManual('cinematic');
+    run(governor, THROTTLED, 30);
+    expect(governor.level).toBe('cinematic');
+
+    governor.setAuto();
+    run(governor, THROTTLED, 60);
+    expect(governor.level).toBe('balanced');
+  });
+});
+
+describe('PerformanceGovernor — climbing', () => {
+  it('climbs to the top of the ladder on a fast GPU', () => {
+    const governor = new PerformanceGovernor('low');
+    const { changes } = run(governor, FAST, 120);
+
+    expect(governor.level).toBe('cinematic');
+    expect(changes.every((c) => c.reason === 'upshift')).toBe(true);
+    expect(changes.map((c) => c.to)).toEqual(['balanced', 'high', 'cinematic']);
+  });
+
+  it('climbs cautiously — measurably slower than it drops', () => {
+    /** Wall-clock seconds until the governor first changes level. */
+    const timeToFirstChange = (
+      governor: PerformanceGovernor,
+      device: DeviceProfile,
+    ): number => {
+      let elapsed = 0;
+      let at: number | null = null;
+      governor.subscribe(() => {
+        at ??= elapsed;
+      });
+      while (elapsed < 60 && at === null) {
+        const frameMs = device[governor.level];
+        governor.sample(frameMs, frameMs / 1000);
+        elapsed += frameMs / 1000;
+      }
+      return at ?? Number.POSITIVE_INFINITY;
+    };
+
+    const downshiftSec = timeToFirstChange(new PerformanceGovernor('cinematic'), THROTTLED);
+    const upshiftSec = timeToFirstChange(new PerformanceGovernor('low'), FAST);
+
+    // React fast to pain, slow to comfort — at least 3x more patient climbing.
+    expect(downshiftSec).toBeLessThan(1.5);
+    expect(upshiftSec).toBeGreaterThan(downshiftSec * 3);
+  });
+
+  it('backs off from a level that keeps failing', () => {
+    // Cheap enough to tempt an upshift, too slow to hold it.
+    const marginal: DeviceProfile = { low: 12.5, balanced: 21, high: 30, cinematic: 40 };
+    const governor = new PerformanceGovernor('low');
+    run(governor, marginal, 200);
+
+    const snapshot = governor.snapshot();
+    expect(snapshot.level).toBe('low');
+    // Each failed attempt at 'balanced' raises the bar for retrying it.
+    expect(snapshot.upshiftPenalties[1]).toBeGreaterThan(0);
+  });
+
+  it('settles at the bottom when nothing fits, without churning', () => {
+    const governor = new PerformanceGovernor('cinematic');
+    const { changes } = run(governor, HOPELESS, 120);
+
+    expect(governor.level).toBe('low');
+    // Exactly one step per rung down, then it stops trying.
+    expect(changes.map((c) => c.to)).toEqual(['high', 'balanced', 'low']);
+  });
+});
+
+describe('PerformanceGovernor — input handling', () => {
+  it('ignores hitches rather than treating them as a trend', () => {
+    const governor = new PerformanceGovernor('high');
+    for (let i = 0; i < 60; i++) governor.sample(10, 0.01);
+    const before = governor.averageFrameTimeMs;
+
+    // A 2-second stall: tab restore, shader compile.
+    expect(governor.sample(2000, 2)).toBeNull();
+    expect(governor.averageFrameTimeMs).toBe(before);
+    expect(governor.level).toBe('high');
+  });
+
+  it('rejects malformed samples', () => {
+    const governor = new PerformanceGovernor('high');
+    for (const bad of [0, -5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(governor.sample(bad, 0.016)).toBeNull();
+    }
+    expect(governor.sample(16, 0)).toBeNull();
+    expect(governor.sample(16, Number.NaN)).toBeNull();
+  });
+
+  it('measures sustain in seconds, so slow devices are not penalised twice', () => {
+    // Same wall time, wildly different sample counts.
+    const coarse = new PerformanceGovernor('cinematic');
+    let coarseElapsed = 0;
+    while (coarseElapsed < 3 && coarse.level === 'cinematic') {
+      coarse.sample(50, 0.05);
+      coarseElapsed += 0.05;
+    }
+
+    const fine = new PerformanceGovernor('cinematic');
+    let fineElapsed = 0;
+    while (fineElapsed < 3 && fine.level === 'cinematic') {
+      fine.sample(50, 0.005);
+      fineElapsed += 0.005;
+    }
+
+    // Both step down at about the same wall-clock moment.
+    expect(Math.abs(coarseElapsed - fineElapsed)).toBeLessThan(0.5);
+  });
+
+  it('notifies subscribers and stops after unsubscribe', () => {
+    const governor = new PerformanceGovernor('cinematic');
+    const listener = vi.fn();
+    const unsubscribe = governor.subscribe(listener);
+
+    run(governor, THROTTLED, 20);
+    expect(listener).toHaveBeenCalled();
+    const callCount = listener.mock.calls.length;
+    const change = listener.mock.calls[0][0] as QualityChange;
+    expect(change.from).toBe('cinematic');
+    expect(change.to).toBe('high');
+    expect(change.frameTimeMs).toBeGreaterThan(0);
+
+    unsubscribe();
+    run(governor, FAST, 60);
+    expect(listener).toHaveBeenCalledTimes(callCount);
+  });
+
+  it('requires a deadband between the two thresholds', () => {
+    expect(
+      () => new PerformanceGovernor('high', { targetFrameTimeMs: 16, upshiftFrameTimeMs: 16 }),
+    ).toThrow(/deadband/);
+    expect(
+      () => new PerformanceGovernor('high', { targetFrameTimeMs: 16, upshiftFrameTimeMs: 20 }),
+    ).toThrow(/deadband/);
+  });
+
+  it('rejects unknown manual levels and exposes the ladder cheapest-first', () => {
+    const governor = new PerformanceGovernor('high');
+    expect(() => governor.setManual('ultra' as QualityLevel)).toThrow(/Unknown quality level/);
+    expect(QUALITY_LADDER).toEqual(['low', 'balanced', 'high', 'cinematic']);
+  });
+});

--- a/src/core/PerformanceGovernor.ts
+++ b/src/core/PerformanceGovernor.ts
@@ -1,0 +1,238 @@
+/**
+ * Closed-loop quality control.
+ *
+ * Steps the quality ladder to hold a frame-time budget: drop quickly when the
+ * frame is over budget, climb slowly and only with real headroom. Kept as a
+ * pure state machine fed by frame-time samples -- no timers, no globals -- so
+ * the convergence and stability behaviour can be simulated and asserted rather
+ * than eyeballed on a device.
+ *
+ * The input is a frame time in milliseconds, whatever its source: GPU
+ * timestamp-query totals where available, rAF deltas otherwise.
+ */
+
+import type { QualityLevel } from './QualityPresets.js';
+
+/** Cheapest first. Index in this array is the governor's control variable. */
+export const QUALITY_LADDER: readonly QualityLevel[] = ['low', 'balanced', 'high', 'cinematic'];
+
+export type GovernorMode = 'auto' | 'manual';
+
+export type QualityChangeReason = 'downshift' | 'upshift' | 'manual' | 'initial';
+
+export interface QualityChange {
+  from: QualityLevel;
+  to: QualityLevel;
+  reason: QualityChangeReason;
+  /** Averaged frame time that triggered the change, in ms. */
+  frameTimeMs: number;
+}
+
+export interface PerformanceGovernorOptions {
+  /** Over this averaged frame time, quality steps down. 18ms ~= 55fps. */
+  targetFrameTimeMs?: number;
+  /**
+   * Under this, quality may step up. The gap between this and the target is
+   * the deadband -- the single most important anti-oscillation device, since a
+   * level that lands between the two is left alone.
+   */
+  upshiftFrameTimeMs?: number;
+  /** Sustained time over budget before stepping down. */
+  downshiftSustainSec?: number;
+  /** Sustained headroom before stepping up. Deliberately much longer. */
+  upshiftSustainSec?: number;
+  /** Quiet period after a downshift; short, so descent stays fast. */
+  downshiftCooldownSec?: number;
+  /** Quiet period after an upshift; long, so probing is rare. */
+  upshiftCooldownSec?: number;
+  /**
+   * Each failed attempt at a level doubles the headroom it demands next time,
+   * up to this many doublings. Without it, a device sitting near a boundary
+   * would climb and fall forever.
+   */
+  maxUpshiftBackoff?: number;
+  /** Ignore samples above this; a hitch is not a trend. */
+  maxPlausibleFrameTimeMs?: number;
+  /** Smoothing factor for the frame-time average, per sample. */
+  smoothing?: number;
+}
+
+const DEFAULTS: Required<PerformanceGovernorOptions> = {
+  targetFrameTimeMs: 18,
+  upshiftFrameTimeMs: 13,
+  downshiftSustainSec: 1.0,
+  upshiftSustainSec: 4.0,
+  downshiftCooldownSec: 0.5,
+  upshiftCooldownSec: 3.0,
+  maxUpshiftBackoff: 4,
+  maxPlausibleFrameTimeMs: 500,
+  smoothing: 0.15,
+};
+
+export type GovernorListener = (change: QualityChange) => void;
+
+export interface GovernorSnapshot {
+  mode: GovernorMode;
+  level: QualityLevel;
+  averageFrameTimeMs: number;
+  overBudgetSec: number;
+  headroomSec: number;
+  cooldownRemainingSec: number;
+  /** Backoff exponent per ladder index; grows each time a level fails. */
+  upshiftPenalties: readonly number[];
+}
+
+export class PerformanceGovernor {
+  private readonly options: Required<PerformanceGovernorOptions>;
+  private readonly listeners = new Set<GovernorListener>();
+
+  private mode: GovernorMode = 'auto';
+  private index: number;
+  private average = 0;
+  private sampleCount = 0;
+  private overBudgetSec = 0;
+  private headroomSec = 0;
+  private cooldownSec = 0;
+  /** Per-level count of failed upshift attempts. */
+  private penalties: number[];
+
+  constructor(initialLevel: QualityLevel = 'high', options: PerformanceGovernorOptions = {}) {
+    this.options = { ...DEFAULTS, ...options };
+    if (this.options.upshiftFrameTimeMs >= this.options.targetFrameTimeMs) {
+      throw new RangeError(
+        'upshiftFrameTimeMs must be below targetFrameTimeMs to leave a deadband.',
+      );
+    }
+    this.index = Math.max(0, QUALITY_LADDER.indexOf(initialLevel));
+    this.penalties = QUALITY_LADDER.map(() => 0);
+  }
+
+  get level(): QualityLevel {
+    return QUALITY_LADDER[this.index];
+  }
+
+  get currentMode(): GovernorMode {
+    return this.mode;
+  }
+
+  get averageFrameTimeMs(): number {
+    return this.average;
+  }
+
+  subscribe(listener: GovernorListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  /** Pin to a level and stop adapting. */
+  setManual(level: QualityLevel): void {
+    const index = QUALITY_LADDER.indexOf(level);
+    if (index < 0) throw new RangeError(`Unknown quality level: ${level}`);
+    const from = this.level;
+    this.mode = 'manual';
+    this.index = index;
+    this.resetAccumulators();
+    if (from !== level) {
+      this.emit({ from, to: level, reason: 'manual', frameTimeMs: this.average });
+    }
+  }
+
+  /** Hand control back to the governor, starting from the current level. */
+  setAuto(): void {
+    this.mode = 'auto';
+    this.resetAccumulators();
+    this.penalties = QUALITY_LADDER.map(() => 0);
+  }
+
+  /**
+   * Feed one frame. Returns the new level if it changed, else null.
+   *
+   * `deltaSec` is the wall time this sample covers, so the sustain windows are
+   * measured in seconds rather than in frames -- otherwise a slow device, which
+   * produces fewer samples per second, would react more slowly than a fast one.
+   */
+  sample(frameTimeMs: number, deltaSec: number): QualityLevel | null {
+    if (!Number.isFinite(frameTimeMs) || frameTimeMs <= 0) return null;
+    if (!Number.isFinite(deltaSec) || deltaSec <= 0) return null;
+    // A single stall (tab restore, shader compile) must not move the ladder.
+    if (frameTimeMs > this.options.maxPlausibleFrameTimeMs) return null;
+
+    this.sampleCount++;
+    this.average =
+      this.sampleCount === 1
+        ? frameTimeMs
+        : this.average + (frameTimeMs - this.average) * this.options.smoothing;
+
+    if (this.mode === 'manual') return null;
+
+    this.cooldownSec = Math.max(0, this.cooldownSec - deltaSec);
+
+    const { targetFrameTimeMs, upshiftFrameTimeMs } = this.options;
+    if (this.average > targetFrameTimeMs) {
+      this.overBudgetSec += deltaSec;
+      this.headroomSec = 0;
+    } else if (this.average < upshiftFrameTimeMs) {
+      this.headroomSec += deltaSec;
+      this.overBudgetSec = 0;
+    } else {
+      // Inside the deadband: the current level is a good fit, so let both
+      // accumulators decay rather than creeping toward a change.
+      this.overBudgetSec = Math.max(0, this.overBudgetSec - deltaSec);
+      this.headroomSec = Math.max(0, this.headroomSec - deltaSec);
+    }
+
+    if (this.cooldownSec > 0) return null;
+
+    if (this.overBudgetSec >= this.options.downshiftSustainSec && this.index > 0) {
+      // The level we are leaving just failed; make it harder to return to.
+      this.penalties[this.index] = Math.min(
+        this.options.maxUpshiftBackoff,
+        this.penalties[this.index] + 1,
+      );
+      return this.step(-1, 'downshift');
+    }
+
+    if (this.index < QUALITY_LADDER.length - 1) {
+      const required = this.options.upshiftSustainSec * 2 ** this.penalties[this.index + 1];
+      if (this.headroomSec >= required) {
+        return this.step(1, 'upshift');
+      }
+    }
+
+    return null;
+  }
+
+  snapshot(): GovernorSnapshot {
+    return {
+      mode: this.mode,
+      level: this.level,
+      averageFrameTimeMs: this.average,
+      overBudgetSec: this.overBudgetSec,
+      headroomSec: this.headroomSec,
+      cooldownRemainingSec: this.cooldownSec,
+      upshiftPenalties: [...this.penalties],
+    };
+  }
+
+  private step(direction: 1 | -1, reason: QualityChangeReason): QualityLevel {
+    const from = this.level;
+    this.index += direction;
+    this.cooldownSec =
+      direction === -1 ? this.options.downshiftCooldownSec : this.options.upshiftCooldownSec;
+    this.overBudgetSec = 0;
+    this.headroomSec = 0;
+    const to = this.level;
+    this.emit({ from, to, reason, frameTimeMs: this.average });
+    return to;
+  }
+
+  private resetAccumulators(): void {
+    this.overBudgetSec = 0;
+    this.headroomSec = 0;
+    this.cooldownSec = 0;
+  }
+
+  private emit(change: QualityChange): void {
+    for (const listener of this.listeners) listener(change);
+  }
+}

--- a/src/styles/controls-advanced.css
+++ b/src/styles/controls-advanced.css
@@ -753,3 +753,30 @@ button:focus-visible {
   transition-duration: 0.001ms !important;
   scroll-behavior: auto !important;
 }
+
+/* Transient HUD hint (quality changes, etc.) */
+#hud-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 48px;
+  transform: translateX(-50%) translateY(8px);
+  z-index: 2500;
+  padding: 8px 18px;
+  border: 1px solid rgba(102, 204, 255, 0.5);
+  border-radius: 6px;
+  background: rgba(0, 12, 24, 0.92);
+  color: #cfe9ff;
+  font-family: 'Courier New', monospace;
+  font-size: 13px;
+  letter-spacing: 0.05em;
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity 0.25s ease,
+    transform 0.25s ease;
+}
+
+#hud-toast.visible {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}

--- a/src/ui/PerformanceDashboard.ts
+++ b/src/ui/PerformanceDashboard.ts
@@ -353,11 +353,13 @@ export class PerformanceDashboard {
   /**
    * Update quality preset display and track transitions
    */
-  updateQualityPreset(level: QualityLevel): void {
+  updateQualityPreset(level: QualityLevel, governorMode?: 'auto' | 'manual'): void {
     if (!this.elements) return;
 
     const preset = QUALITY_PRESETS[level];
-    this.elements.presetLabel.textContent = preset.label;
+    // Show who is driving, so an unexpected level is traceable to the governor.
+    this.elements.presetLabel.textContent =
+      governorMode === 'auto' ? `${preset.label} (AUTO)` : preset.label;
 
     // Add transition animation class for visual feedback
     const presetEl = this.elements.presetLabel;

--- a/src/ui/UIManager.ts
+++ b/src/ui/UIManager.ts
@@ -63,6 +63,7 @@ export class UIManager {
     onRealismChange: null,
     onConstellationChipClick: null,
     onQualityChange: null,
+    onAutoQualityChange: null,
     onSpeedChange: null,
     onLoopToggle: null,
     onDemoToggle: null,
@@ -94,6 +95,7 @@ export class UIManager {
   private dashboard: IDashboard | null = null;
   private currentQualityLevel: QualityLevel = 'high';
   private demoAutoEnabled = true;
+  private toastTimeout: number | null = null;
   private getClock: (() => SimClock) | null = null;
 
   constructor() {
@@ -170,10 +172,24 @@ export class UIManager {
 
   setActiveQualityButton(level: QualityLevel): void {
     this.elements.qualityButtons.forEach((btn) => {
-      const btnLevel = btn?.dataset.quality as QualityLevel | undefined;
+      const btnLevel = btn?.dataset.quality;
       btn?.classList.toggle('active', btnLevel === level);
     });
     this.setQualityDisplay(level);
+  }
+
+  /** Highlight AUTO; the level readout keeps tracking whatever the governor picks. */
+  setAutoQuality(): void {
+    this.elements.qualityButtons.forEach((btn) => {
+      btn?.classList.toggle('active', btn?.dataset.quality === 'auto');
+    });
+  }
+
+  /** True while AUTO is the selected mode. */
+  isAutoQuality(): boolean {
+    return this.elements.qualityButtons.some(
+      (btn) => btn?.dataset.quality === 'auto' && btn.classList.contains('active'),
+    );
   }
 
   setQualityDisplay(level: QualityLevel): void {
@@ -184,7 +200,7 @@ export class UIManager {
 
     this.currentQualityLevel = level;
     if (this.dashboard) {
-      this.dashboard.updateQualityPreset(level);
+      this.dashboard.updateQualityPreset(level, this.isAutoQuality() ? 'auto' : 'manual');
     }
   }
 
@@ -345,7 +361,10 @@ export class UIManager {
       const { PerformanceDashboard } = await import('@/ui/PerformanceDashboard.js');
       this.dashboard = new PerformanceDashboard(profiler);
       this.dashboard.initialize();
-      this.dashboard.updateQualityPreset(this.currentQualityLevel);
+      this.dashboard.updateQualityPreset(
+        this.currentQualityLevel,
+        this.isAutoQuality() ? 'auto' : 'manual',
+      );
     }
   }
 
@@ -401,6 +420,29 @@ export class UIManager {
     callback: (catalogId: ChipCatalogId, shiftKey: boolean) => void,
   ): void {
     this.callbacks.onConstellationChipClick = callback;
+  }
+
+  onAutoQualityChange(callback: () => void): void {
+    this.callbacks.onAutoQualityChange = callback;
+  }
+
+  /** Transient HUD hint, e.g. when the governor changes level. */
+  showToast(message: string, durationMs = 2600): void {
+    let toast = document.getElementById('hud-toast');
+    if (!toast) {
+      toast = document.createElement('div');
+      toast.id = 'hud-toast';
+      toast.setAttribute('role', 'status');
+      toast.setAttribute('aria-live', 'polite');
+      document.body.appendChild(toast);
+    }
+    toast.textContent = message;
+    toast.classList.add('visible');
+    if (this.toastTimeout !== null) clearTimeout(this.toastTimeout);
+    this.toastTimeout = window.setTimeout(() => {
+      toast?.classList.remove('visible');
+      this.toastTimeout = null;
+    }, durationMs);
   }
 
   onQualityChange(callback: (level: QualityLevel) => void): void {

--- a/src/ui/uiManagerSetup.ts
+++ b/src/ui/uiManagerSetup.ts
@@ -18,6 +18,7 @@ export interface UIManagerSetupCallbacks {
   onRealismChange: ((enabled: boolean) => void) | null;
   onConstellationChipClick: ((catalogId: ChipCatalogId, shiftKey: boolean) => void) | null;
   onQualityChange: ((level: QualityLevel) => void) | null;
+  onAutoQualityChange?: (() => void) | null;
   onSpeedChange: ((speed: number) => void) | null;
   onLoopToggle: ((loop: boolean) => void) | null;
   onDemoToggle: (() => void) | null;
@@ -44,6 +45,7 @@ export interface UIManagerSetupActions {
   setActivePhysicsButton(mode: number): void;
   setActiveRealismButton(enabled: boolean): void;
   setActiveQualityButton(level: QualityLevel): void;
+  setAutoQuality(): void;
   setAudioMuted(muted: boolean): void;
   setTrailsEnabled(enabled: boolean): void;
   setDemoAutoEnabled(enabled: boolean): void;
@@ -107,6 +109,7 @@ export function getElements(): UIElements {
       document.getElementById('realism1') as HTMLButtonElement,
     ],
     qualityButtons: [
+      document.getElementById('qauto') as HTMLButtonElement,
       document.getElementById('qlow') as HTMLButtonElement,
       document.getElementById('qbal') as HTMLButtonElement,
       document.getElementById('qhigh') as HTMLButtonElement,
@@ -294,7 +297,13 @@ export function setupEventListeners(ctx: UIManagerSetupContext): void {
   elements.qualityButtons.forEach((btn) => {
     btn?.addEventListener('click', (e) => {
       const target = e.target as HTMLButtonElement;
-      const level = (target.dataset.quality || 'high') as QualityLevel;
+      const choice = target.dataset.quality || 'high';
+      if (choice === 'auto') {
+        actions.setAutoQuality();
+        callbacks.onAutoQualityChange?.();
+        return;
+      }
+      const level = choice as QualityLevel;
       actions.setActiveQualityButton(level);
       if (callbacks.onQualityChange) {
         callbacks.onQualityChange(level);

--- a/src/ui/uiTypes.ts
+++ b/src/ui/uiTypes.ts
@@ -94,7 +94,7 @@ export interface AnimationUIState {
 export interface IDashboard {
   initialize(): void;
   updateStats(stats: PerformanceStats): void;
-  updateQualityPreset(level: QualityLevel): void;
+  updateQualityPreset(level: QualityLevel, governorMode?: 'auto' | 'manual'): void;
   updatePresentationMode(mode: PresentationMode): void;
   updateSgp4Benchmark(result: Sgp4BenchmarkResult | null, backend: 'wasm' | 'js'): void;
   destroy(): void;


### PR DESCRIPTION
## What this does

Quality was a manual preset, so an iGPU sat at 15 FPS until the user found the setting and a 4090 idled at the default. `PerformanceGovernor` closes the loop: it consumes frame times and steps the quality ladder to hold an 18 ms budget.

It's a **pure state machine fed by frame-time samples** — no timers, no globals, no DOM. That's the design choice that matters here: it means "converges within 10 seconds" and "no visible oscillation" become things I can simulate and assert, rather than claims resting on a device I can't reach.

## Anti-oscillation

Three mechanisms, each independently covered by a test that fails when it's removed:

| Mechanism | Why |
|---|---|
| **Deadband** — drop above 18 ms, climb only below 13 ms | A level that fits comfortably is left alone. This is the big one. |
| **Asymmetric sustain** — 1 s over budget to drop, 4 s of headroom to climb | React fast to pain, slow to comfort. |
| **Per-level backoff** — each failed attempt doubles the headroom that level demands next time | A device sitting near a boundary stops probing instead of climbing and falling forever. |

Two subtler points: sustain is measured in **seconds, not frames**, so a slow device isn't penalised twice for producing fewer samples; and implausible samples are dropped, since a tab restore or shader compile is a hitch, not a trend.

## Acceptance criteria

| Criterion | Result |
|---|---|
| ≥ 50 FPS within 10 s on a throttled GPU, no user action | **2.0 s** to reach `balanced` (15.5 ms ≈ 64 FPS), starting from `cinematic` at 42 ms ≈ 24 FPS |
| No visible oscillation | Monotonic descent, then **zero** further changes across a simulated 120 s. A separate profile parked right on the boundary (17.5 ms / 18.4 ms — the classic flapping setup) produces exactly **one** change in 300 s. Also tested with ±3.5 ms jitter. |
| Manual preset fully disables the governor | Pinned to a level the device can't sustain and left there: **0** changes in 120 s |

Simulated against three device profiles (throttled iGPU, fast GPU, and a "hopeless" device where even `low` misses budget — it settles at the bottom without churning). The harness is a **closed loop**: it feeds back the level the governor selects and reads the resulting frame time, rather than replaying a fixed trace.

**Mutation-checked** — removing the deadband breaks 3 oscillation tests, removing the backoff breaks 1, and making the sustain windows symmetric breaks 2.

## Wiring

- **AUTO is the default** quality option; any preset pins the governor, AUTO hands control back.
- Level changes raise a polite `role="status"` HUD toast ("Performance mode: balanced").
- The performance dashboard marks the preset `(AUTO)`, so an unexpected level is traceable to the governor.
- Frame time comes from the profiler, which **already** prefers GPU timestamp-query totals and falls back to rAF deltas — so proposed item 5 needs no separate sensing path.

## Verification

- 245 unit tests pass (16 new), `tsc --noEmit` clean, `vite build` succeeds
- Re-ran the a11y Playwright suite in real Chromium — **9/9 pass**, confirming the new AUTO button and UI changes didn't regress the app or its accessibility

## Not included: the render-scale knob

Proposed item 2 asks for the ladder to become individually-costed knobs, calling out **resolution scale as "likely the single biggest lever and currently missing"** — and I agree, but I did not add it. It requires a scale factor plumbed through `RenderTargets` and every dependent pass, and I have no GPU here to confirm the targets reallocate correctly or to measure whether the lever pays off. Shipping that blind risks breaking rendering outright.

The governor is knob-agnostic — it drives ladder indices — so adding render scale later is a change to what a rung *means*, not to the control loop. Worth doing as a follow-up by someone who can watch it run.

One pre-existing lint error remains in `src/app/loadSatelliteOrbitalData.ts`, untouched by this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YWfxNTrqEZdC3V2sAAkuD1)_